### PR TITLE
Add configurable display rotation support for S3 

### DIFF
--- a/guition-esp32-s3-4848s040/device/device.yaml
+++ b/guition-esp32-s3-4848s040/device/device.yaml
@@ -245,6 +245,9 @@ touchscreen:
   - platform: gt911
     id: tft_touch
     display: tft_display
+    transform:
+      mirror_x: ${touch_mirror_x}
+      mirror_y: ${touch_mirror_y}
     on_touch:
       - lambda: |-
           id(was_screen_dimmed) = id(is_screen_dimmed);
@@ -639,6 +642,7 @@ script:
 display:
   - platform: st7701s
     id: tft_display
+    rotation: ${display_rotation}
     dimensions:
       width: 480
       height: 480

--- a/guition-esp32-s3-4848s040/packages.yaml
+++ b/guition-esp32-s3-4848s040/packages.yaml
@@ -1,6 +1,16 @@
 substitutions:
   media_player: ""
   tv_media_player: ""
+  # Display rotation in degrees: 0, 90, 180, or 270
+  # Rotate to match your preferred mounting orientation / power cable direction
+  display_rotation: "0"
+  # Touch transform (must match display_rotation):
+  #   0:   mirror_x "false", mirror_y "false"
+  #   90:  mirror_x "true",  mirror_y "false"
+  #   180: mirror_x "true",  mirror_y "true"
+  #   270: mirror_x "false", mirror_y "true"
+  touch_mirror_x: "false"
+  touch_mirror_y: "false"
 
 packages:
   music: !include addon/music.yaml


### PR DESCRIPTION
With hardware-verified touch transform values for all four orientations (0, 90, 180, 270). By which I mean, I did all four and poked the screen to make sure I'd done it right (I definitely didn't, the first couple of times). I have a P4 shipping to me, should get here soon-ish, and I'll add support for it as well, once I can manually verify that the settings are right.

Thanks *tons* for this, btw. It is super-cool.