### PR TITLE
Fix online_image ignoring new URLs during active download

### DIFF
--- a/components/online_image/online_image.cpp
+++ b/components/online_image/online_image.cpp
@@ -99,6 +99,9 @@ size_t OnlineImage::resize_(int width_in, int height_in) {
   size_t new_size = this->get_buffer_size_(width, height);
   if (this->buffer_) {
     if (new_size <= this->get_buffer_size_()) {
+      // Clear reused buffer to prevent stale pixels from a previous (larger)
+      // image showing through if the new decode doesn't fill every row.
+      memset(this->buffer_, 0, this->get_buffer_size_());
       this->buffer_width_ = width;
       this->buffer_height_ = height;
       this->width_ = width;
@@ -125,8 +128,8 @@ size_t OnlineImage::resize_(int width_in, int height_in) {
 
 void OnlineImage::update() {
   if (this->decoder_) {
-    ESP_LOGW(TAG, "Image already being updated.");
-    return;
+    ESP_LOGW(TAG, "Cancelling in-progress image download to fetch new URL");
+    this->end_connection_();
   }
   ESP_LOGI(TAG, "Updating image %s", this->url_.c_str());
 


### PR DESCRIPTION
This came about from an investigation into why I was seeing one album's cover art well into playback of another album. I *think* this should fix it (and a tiny cleanup of possible visual noise) but because it's intermittent I can't say 100% that it's gone. But it at least *works*, in that I can skip around, and playback tracks, and the album art stays in sync.

update() previously rejected new download requests while a decoder was active, causing album art to freeze when tracks changed rapidly. Now cancels the in-progress download and starts the new one. Also clears reused image buffers to prevent stale pixel artifacts.

