### PR TITLE
Add display rotation support for ESP32-P4 (landscape flip)

### DIFF
--- a/docs/advanced/manual-setup.md
+++ b/docs/advanced/manual-setup.md
@@ -61,24 +61,30 @@ These substitutions can be added to the `substitutions:` block in your configura
 | `linked_media_player` | `""`                | Entity ID of a linked media player for TV or Line In source (optional)     |
 | `ha_host`         | `"homeassistant.local"` | Hostname or IP address of Home Assistant                                   |
 | `ha_port`         | `"8123"`                | Port that Home Assistant is running on                                     |
-| `display_rotation` | `"0"`                  | Display rotation in degrees: 0, 90, 180, or 270. ESP32-S3 only.           |
-| `touch_mirror_x`  | `"false"`               | Touch X-axis mirror — must match `display_rotation`. ESP32-S3 only.       |
-| `touch_mirror_y`  | `"false"`               | Touch Y-axis mirror — must match `display_rotation`. ESP32-S3 only.       |
+| `display_rotation` | `"0"` (S3) / `"90"` (P4) | Display rotation in degrees. See [Display rotation](#display-rotation).  |
+| `touch_mirror_x`  | `"false"`               | Touch X-axis mirror — must match `display_rotation`. See rotation tables. |
+| `touch_mirror_y`  | `"false"`               | Touch Y-axis mirror — must match `display_rotation`. See rotation tables. |
 
-## Display rotation (ESP32-S3 only)
+## Display rotation
 
-If you mount the ESP32-S3 4848S040 in a different orientation (for example to change which side the power cable exits from), you can rotate the display by setting the `display_rotation` substitution to `0`, `90`, `180`, or `270` degrees.
+Both devices support display rotation for different mounting orientations (for example to change which side the power cable exits from). Set `display_rotation` and update `touch_mirror_x` / `touch_mirror_y` to match.
 
-You **must** also set `touch_mirror_x` and `touch_mirror_y` to match the rotation, otherwise touch input will not align with the display. Use the table below:
+::: warning
+If you set `display_rotation` without updating the touch mirror values, the screen image will be rotated but taps will register in the wrong position.
+:::
+
+### ESP32-S3 4848S040
+
+The 480×480 square display supports all four rotations:
 
 | `display_rotation` | `touch_mirror_x` | `touch_mirror_y` |
 | ------------------- | ----------------- | ----------------- |
-| `"0"`               | `"false"`         | `"false"`         |
+| `"0"` (default)     | `"false"`         | `"false"`         |
 | `"90"`              | `"true"`          | `"false"`         |
 | `"180"`             | `"true"`          | `"true"`          |
 | `"270"`             | `"false"`         | `"true"`          |
 
-### Example: 90-degree rotation
+#### Example: 90-degree rotation
 
 ```yaml
 substitutions:
@@ -100,9 +106,36 @@ packages:
     refresh: 1s
 ```
 
-::: warning
-If you set `display_rotation` without updating the touch mirror values, the screen image will be rotated but taps will register in the wrong position.
-:::
+### ESP32-P4 JC8012P4A1
+
+The 1280×800 rectangular display defaults to landscape (90°). To flip it 180° (e.g. to reverse the power cable side), use 270°:
+
+| `display_rotation` | `touch_mirror_x` | `touch_mirror_y` |
+| ------------------- | ----------------- | ----------------- |
+| `"90"` (default)    | `"false"`         | `"false"`         |
+| `"270"`             | `"true"`          | `"true"`          |
+
+#### Example: flipped landscape
+
+```yaml
+substitutions:
+  name: "music-dashboard-10inch"
+  friendly_name: "Music Dashboard 10inch"
+  display_rotation: "270"
+  touch_mirror_x: "true"
+  touch_mirror_y: "true"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+packages:
+  music_dashboard:
+    url: https://github.com/jtenniswood/esphome-media-player
+    files: [guition-esp32-p4-jc8012p4a1/packages.yaml]
+    ref: main
+    refresh: 1s
+```
 
 ## Non-standard Home Assistant host or port
 

--- a/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -201,8 +201,8 @@ touchscreen:
     interrupt_pin: GPIO21
     transform:
       swap_xy: true
-      mirror_x: false
-      mirror_y: false
+      mirror_x: ${touch_mirror_x}
+      mirror_y: ${touch_mirror_y}
     on_touch:
       - lambda: |-
           id(was_screen_dimmed) = id(is_screen_dimmed);
@@ -488,7 +488,7 @@ display:
     model: JC8012P4A1
     id: tft_display
     reset_pin: GPIO27
-    rotation: 90
+    rotation: ${display_rotation}
     auto_clear_enabled: false
     color_order: RGB
     dimensions:

--- a/guition-esp32-p4-jc8012p4a1/esphome.yaml
+++ b/guition-esp32-p4-jc8012p4a1/esphome.yaml
@@ -4,6 +4,13 @@ substitutions:
   friendly_name: "Music Dashboard 10inch"
   # ha_host: "homeassistant.local"  # Home Assistant hostname or IP (change if HA runs on a different host)
   # ha_port: "8123"  # Home Assistant port (change if HA runs on a non-standard port)
+  # Display rotation: 90 (default landscape) or 270 (flipped landscape)
+  # display_rotation: "270"
+  # Touch transform (must match display_rotation):
+  #   90:  touch_mirror_x "false", touch_mirror_y "false"
+  #   270: touch_mirror_x "true",  touch_mirror_y "true"
+  # touch_mirror_x: "true"
+  # touch_mirror_y: "true"
 
 # Wifi Setup
 wifi:

--- a/guition-esp32-p4-jc8012p4a1/packages.yaml
+++ b/guition-esp32-p4-jc8012p4a1/packages.yaml
@@ -3,6 +3,14 @@ substitutions:
   linked_media_player: ""
   ha_port: "8123"
   ha_host: "homeassistant.local"
+  # Display rotation: 90 (default landscape) or 270 (flipped landscape)
+  # Flip to 270 if mounting with the power cable on the opposite side
+  display_rotation: "90"
+  # Touch transform (must match display_rotation):
+  #   90:  touch_mirror_x "false", touch_mirror_y "false"
+  #   270: touch_mirror_x "true",  touch_mirror_y "true"
+  touch_mirror_x: "false"
+  touch_mirror_y: "false"
 
 packages:
   music: !include addon/music.yaml


### PR DESCRIPTION
I said I would submit this once I got a P4 to test it with and well, my P4 arrived today! 🥳 

Supports 90° (default) and 270° (flipped) landscape orientations via display_rotation, touch_mirror_x, and touch_mirror_y substitutions, matching the existing ESP32-S3 rotation pattern.