### PR TITLE
Add 12-hour clock format with AM/PM for screensaver

### DIFF
--- a/guition-esp32-p4-jc8012p4a1/addon/backlight.yaml
+++ b/guition-esp32-p4-jc8012p4a1/addon/backlight.yaml
@@ -238,6 +238,14 @@ switch:
     icon: "mdi:clock-outline"
     entity_category: config
 
+  - platform: template
+    name: "Screen Saver: 24-Hour Clock"
+    id: clock_24h_enabled
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    icon: "mdi:clock-digital"
+    entity_category: config
+
 
 # -----------------------------------------------------------------------------
 # BACKLIGHT WAKE / DIM / OFF SCRIPT
@@ -349,7 +357,13 @@ script:
           auto time = id(ha_time).now();
           if (time.is_valid()) {
             char buf[6];
-            snprintf(buf, sizeof(buf), "%02d:%02d", time.hour, time.minute);
+            if (id(clock_24h_enabled).state) {
+              snprintf(buf, sizeof(buf), "%02d:%02d", time.hour, time.minute);
+            } else {
+              int h12 = time.hour % 12;
+              if (h12 == 0) h12 = 12;
+              snprintf(buf, sizeof(buf), "%2d:%02d", h12, time.minute);
+            }
             lv_label_set_text(id(clock_label), buf);
             lv_obj_update_layout(id(clock_label));
             lv_coord_t w = lv_obj_get_width(id(clock_label));
@@ -358,6 +372,16 @@ script:
             int ox = (time.minute * 7) % 61 - 30;
             int oy = (time.minute * 13) % 41 - 20;
             lv_obj_set_pos(id(clock_label), cx + ox - w/2, cy + oy - h/2);
+            if (id(clock_24h_enabled).state) {
+              lv_obj_add_flag(id(am_pm_label), LV_OBJ_FLAG_HIDDEN);
+            } else {
+              lv_label_set_text(id(am_pm_label), time.hour < 12 ? "AM" : "PM");
+              lv_obj_clear_flag(id(am_pm_label), LV_OBJ_FLAG_HIDDEN);
+              lv_obj_update_layout(id(am_pm_label));
+              lv_coord_t pw = lv_obj_get_width(id(am_pm_label));
+              lv_coord_t ph = lv_obj_get_height(id(am_pm_label));
+              lv_obj_set_pos(id(am_pm_label), cx + ox + w/2 - pw, cy + oy + h/2 - ph);
+            }
           }
       - lvgl.widget.show: clock_screensaver
       - light.turn_on:
@@ -407,7 +431,13 @@ interval:
           auto time = id(ha_time).now();
           if (!time.is_valid()) return;
           char buf[6];
-          snprintf(buf, sizeof(buf), "%02d:%02d", time.hour, time.minute);
+          if (id(clock_24h_enabled).state) {
+            snprintf(buf, sizeof(buf), "%02d:%02d", time.hour, time.minute);
+          } else {
+            int h12 = time.hour % 12;
+            if (h12 == 0) h12 = 12;
+            snprintf(buf, sizeof(buf), "%2d:%02d", h12, time.minute);
+          }
           lv_label_set_text(id(clock_label), buf);
           lv_obj_update_layout(id(clock_label));
           lv_coord_t w = lv_obj_get_width(id(clock_label));
@@ -416,3 +446,13 @@ interval:
           int ox = (time.minute * 7) % 61 - 30;
           int oy = (time.minute * 13) % 41 - 20;
           lv_obj_set_pos(id(clock_label), cx + ox - w/2, cy + oy - h/2);
+          if (id(clock_24h_enabled).state) {
+            lv_obj_add_flag(id(am_pm_label), LV_OBJ_FLAG_HIDDEN);
+          } else {
+            lv_label_set_text(id(am_pm_label), time.hour < 12 ? "AM" : "PM");
+            lv_obj_clear_flag(id(am_pm_label), LV_OBJ_FLAG_HIDDEN);
+            lv_obj_update_layout(id(am_pm_label));
+            lv_coord_t pw = lv_obj_get_width(id(am_pm_label));
+            lv_coord_t ph = lv_obj_get_height(id(am_pm_label));
+            lv_obj_set_pos(id(am_pm_label), cx + ox + w/2 - pw, cy + oy + h/2 - ph);
+          }

--- a/guition-esp32-p4-jc8012p4a1/addon/backlight.yaml
+++ b/guition-esp32-p4-jc8012p4a1/addon/backlight.yaml
@@ -245,6 +245,12 @@ switch:
     restore_mode: RESTORE_DEFAULT_ON
     icon: "mdi:clock-digital"
     entity_category: config
+    on_state:
+      - if:
+          condition:
+            lambda: 'return id(is_clock_showing);'
+          then:
+            - script.execute: show_clock_view
 
 
 # -----------------------------------------------------------------------------

--- a/guition-esp32-p4-jc8012p4a1/assets/fonts.yaml
+++ b/guition-esp32-p4-jc8012p4a1/assets/fonts.yaml
@@ -3,12 +3,19 @@
 # symbols (©, ®, ™, €, •, etc.) and typographic quotes (' ' " ") for song metadata.
 # Two content lines in each >- block: the fold produces exactly one space glyph.
 # roboto_thin300_font uses Thin weight for the clock screensaver (digits + colon only).
+# roboto_thin_ampm_font uses Thin weight for the AM/PM indicator in 12-hour mode.
 font:
   - file: "gfonts://Roboto@Thin"
     id: roboto_thin300_font
     size: 300
     bpp: 4
     glyphs: " 0123456789:"
+
+  - file: "gfonts://Roboto@Thin"
+    id: roboto_thin_ampm_font
+    size: 60
+    bpp: 4
+    glyphs: "AMP "
 
   - file: "gfonts://Roboto@Light"
     id: roboto_light88_font

--- a/guition-esp32-p4-jc8012p4a1/device/lvgl.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/lvgl.yaml
@@ -2702,3 +2702,9 @@ lvgl:
                   text_font: roboto_thin300_font
                   text_color: 0xFFFFFF
                   text: "00:00"
+              - label:
+                  id: am_pm_label
+                  text_font: roboto_thin_ampm_font
+                  text_color: 0xFFFFFF
+                  text: "AM"
+                  hidden: true

--- a/guition-esp32-s3-4848s040/addon/backlight.yaml
+++ b/guition-esp32-s3-4848s040/addon/backlight.yaml
@@ -227,6 +227,14 @@ switch:
     icon: "mdi:clock-outline"
     entity_category: config
 
+  - platform: template
+    name: "Screen Saver: 24-Hour Clock"
+    id: clock_24h_enabled
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    icon: "mdi:clock-digital"
+    entity_category: config
+
 
 # -----------------------------------------------------------------------------
 # BACKLIGHT WAKE / DIM / OFF SCRIPT
@@ -338,7 +346,13 @@ script:
           auto time = id(ha_time).now();
           if (time.is_valid()) {
             char buf[6];
-            snprintf(buf, sizeof(buf), "%02d:%02d", time.hour, time.minute);
+            if (id(clock_24h_enabled).state) {
+              snprintf(buf, sizeof(buf), "%02d:%02d", time.hour, time.minute);
+            } else {
+              int h12 = time.hour % 12;
+              if (h12 == 0) h12 = 12;
+              snprintf(buf, sizeof(buf), "%2d:%02d", h12, time.minute);
+            }
             lv_label_set_text(id(clock_label), buf);
             lv_obj_update_layout(id(clock_label));
             lv_coord_t w = lv_obj_get_width(id(clock_label));
@@ -347,6 +361,16 @@ script:
             int ox = (time.minute * 7) % 61 - 30;
             int oy = (time.minute * 13) % 41 - 20;
             lv_obj_set_pos(id(clock_label), cx + ox - w/2, cy + oy - h/2);
+            if (id(clock_24h_enabled).state) {
+              lv_obj_add_flag(id(am_pm_label), LV_OBJ_FLAG_HIDDEN);
+            } else {
+              lv_label_set_text(id(am_pm_label), time.hour < 12 ? "AM" : "PM");
+              lv_obj_clear_flag(id(am_pm_label), LV_OBJ_FLAG_HIDDEN);
+              lv_obj_update_layout(id(am_pm_label));
+              lv_coord_t pw = lv_obj_get_width(id(am_pm_label));
+              lv_coord_t ph = lv_obj_get_height(id(am_pm_label));
+              lv_obj_set_pos(id(am_pm_label), cx + ox + w/2 - pw, cy + oy + h/2 - ph);
+            }
           }
       - lvgl.widget.show: clock_screensaver
       - light.turn_on:
@@ -396,7 +420,13 @@ interval:
           auto time = id(ha_time).now();
           if (!time.is_valid()) return;
           char buf[6];
-          snprintf(buf, sizeof(buf), "%02d:%02d", time.hour, time.minute);
+          if (id(clock_24h_enabled).state) {
+            snprintf(buf, sizeof(buf), "%02d:%02d", time.hour, time.minute);
+          } else {
+            int h12 = time.hour % 12;
+            if (h12 == 0) h12 = 12;
+            snprintf(buf, sizeof(buf), "%2d:%02d", h12, time.minute);
+          }
           lv_label_set_text(id(clock_label), buf);
           lv_obj_update_layout(id(clock_label));
           lv_coord_t w = lv_obj_get_width(id(clock_label));
@@ -405,3 +435,13 @@ interval:
           int ox = (time.minute * 7) % 61 - 30;
           int oy = (time.minute * 13) % 41 - 20;
           lv_obj_set_pos(id(clock_label), cx + ox - w/2, cy + oy - h/2);
+          if (id(clock_24h_enabled).state) {
+            lv_obj_add_flag(id(am_pm_label), LV_OBJ_FLAG_HIDDEN);
+          } else {
+            lv_label_set_text(id(am_pm_label), time.hour < 12 ? "AM" : "PM");
+            lv_obj_clear_flag(id(am_pm_label), LV_OBJ_FLAG_HIDDEN);
+            lv_obj_update_layout(id(am_pm_label));
+            lv_coord_t pw = lv_obj_get_width(id(am_pm_label));
+            lv_coord_t ph = lv_obj_get_height(id(am_pm_label));
+            lv_obj_set_pos(id(am_pm_label), cx + ox + w/2 - pw, cy + oy + h/2 - ph);
+          }

--- a/guition-esp32-s3-4848s040/addon/backlight.yaml
+++ b/guition-esp32-s3-4848s040/addon/backlight.yaml
@@ -234,6 +234,12 @@ switch:
     restore_mode: RESTORE_DEFAULT_ON
     icon: "mdi:clock-digital"
     entity_category: config
+    on_state:
+      - if:
+          condition:
+            lambda: 'return id(is_clock_showing);'
+          then:
+            - script.execute: show_clock_view
 
 
 # -----------------------------------------------------------------------------

--- a/guition-esp32-s3-4848s040/assets/fonts.yaml
+++ b/guition-esp32-s3-4848s040/assets/fonts.yaml
@@ -4,12 +4,19 @@
 # Two content lines in each >- block: the fold produces exactly one space glyph.
 # roboto56_font uses regular weight with minimal glyphs (digits + %) for the volume dial.
 # roboto_thin160_font uses Thin weight for the clock screensaver (digits + colon only).
+# roboto_thin_ampm_font uses Thin weight for the AM/PM indicator in 12-hour mode.
 font:
   - file: "gfonts://Roboto@Thin"
     id: roboto_thin160_font
     size: 160
     bpp: 4
     glyphs: " 0123456789:"
+
+  - file: "gfonts://Roboto@Thin"
+    id: roboto_thin_ampm_font
+    size: 40
+    bpp: 4
+    glyphs: "AMP "
 
   - file: "gfonts://Roboto"
     id: roboto56_font

--- a/guition-esp32-s3-4848s040/device/lvgl.yaml
+++ b/guition-esp32-s3-4848s040/device/lvgl.yaml
@@ -2704,3 +2704,9 @@ lvgl:
                   text_font: roboto_thin160_font
                   text_color: 0xFFFFFF
                   text: "00:00"
+              - label:
+                  id: am_pm_label
+                  text_font: roboto_thin_ampm_font
+                  text_color: 0xFFFFFF
+                  text: "AM"
+                  hidden: true


### PR DESCRIPTION
## Summary

- Adds a **Screen Saver: 24-Hour Clock** toggle switch exposed to Home Assistant (defaults ON for 24h)
- When disabled, the screensaver displays time in 12-hour format with a small AM/PM indicator
- AM/PM label uses the same Roboto Thin font, positioned at the bottom-right corner of the time and participates in the burn-in drift alongside the main clock label

## Changes

- `assets/fonts.yaml` (both devices) — new `roboto_thin_ampm_font` (Thin, 40px S3 / 60px P4, glyphs `AMP `)
- `device/lvgl.yaml` (both devices) — new `am_pm_label` widget inside `clock_screensaver`, hidden by default
- `addon/backlight.yaml` (both devices) — new `clock_24h_enabled` switch; both `show_clock_view` and the 30s interval lambda updated to branch on format and manage the AM/PM label

Solves  #63