### PR TITLE
Add 12-hour clock mode to screensaver

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -226,6 +226,20 @@ switch:
     icon: "mdi:clock-outline"
     entity_category: config
 
+  - platform: template
+    name: "Screen Saver: 24-Hour Clock"
+    id: clock_24h_enabled
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    icon: "mdi:clock-digital"
+    entity_category: config
+    on_state:
+      - if:
+          condition:
+            lambda: 'return id(is_clock_showing);'
+          then:
+            - script.execute: show_clock_view
+
 
 # -----------------------------------------------------------------------------
 # BACKLIGHT WAKE / DIM / OFF SCRIPT
@@ -376,22 +390,34 @@ script:
           setenv("TZ", id(tz_posix).c_str(), 1);
           tzset();
           auto time = id(ha_time).now();
-          int hour = 0;
-          int minute = 0;
           if (time.is_valid()) {
-            hour = time.hour;
-            minute = time.minute;
+            char buf[6];
+            if (id(clock_24h_enabled).state) {
+              snprintf(buf, sizeof(buf), "%02d:%02d", time.hour, time.minute);
+            } else {
+              int h12 = time.hour % 12;
+              if (h12 == 0) h12 = 12;
+              snprintf(buf, sizeof(buf), "%2d:%02d", h12, time.minute);
+            }
+            lv_label_set_text(id(clock_label), buf);
+            lv_obj_update_layout(id(clock_label));
+            lv_coord_t w = lv_obj_get_width(id(clock_label));
+            lv_coord_t h = lv_obj_get_height(id(clock_label));
+            int cx = ${clock_cx}, cy = ${clock_cy};
+            int ox = (time.minute * 7) % 61 - 30;
+            int oy = (time.minute * 13) % 41 - 20;
+            lv_obj_set_pos(id(clock_label), cx + ox - w/2, cy + oy - h/2);
+            if (id(clock_24h_enabled).state) {
+              lv_obj_add_flag(id(am_pm_label), LV_OBJ_FLAG_HIDDEN);
+            } else {
+              lv_label_set_text(id(am_pm_label), time.hour < 12 ? "AM" : "PM");
+              lv_obj_clear_flag(id(am_pm_label), LV_OBJ_FLAG_HIDDEN);
+              lv_obj_update_layout(id(am_pm_label));
+              lv_coord_t pw = lv_obj_get_width(id(am_pm_label));
+              lv_coord_t ph = lv_obj_get_height(id(am_pm_label));
+              lv_obj_set_pos(id(am_pm_label), cx + ox + w/2 - pw, cy + oy + h/2 - ph);
+            }
           }
-          char buf[6];
-          snprintf(buf, sizeof(buf), "%02d:%02d", hour, minute);
-          lv_label_set_text(id(clock_label), buf);
-          lv_obj_update_layout(id(clock_label));
-          lv_coord_t w = lv_obj_get_width(id(clock_label));
-          lv_coord_t h = lv_obj_get_height(id(clock_label));
-          int cx = ${clock_cx}, cy = ${clock_cy};
-          int ox = (minute * 7) % 61 - 30;
-          int oy = (minute * 13) % 41 - 20;
-          lv_obj_set_pos(id(clock_label), cx + ox - w/2, cy + oy - h/2);
       - lvgl.widget.redraw:
       - light.turn_on:
           id: backlight
@@ -454,7 +480,13 @@ interval:
           auto time = id(ha_time).now();
           if (!time.is_valid()) return;
           char buf[6];
-          snprintf(buf, sizeof(buf), "%02d:%02d", time.hour, time.minute);
+          if (id(clock_24h_enabled).state) {
+            snprintf(buf, sizeof(buf), "%02d:%02d", time.hour, time.minute);
+          } else {
+            int h12 = time.hour % 12;
+            if (h12 == 0) h12 = 12;
+            snprintf(buf, sizeof(buf), "%2d:%02d", h12, time.minute);
+          }
           lv_label_set_text(id(clock_label), buf);
           lv_obj_update_layout(id(clock_label));
           lv_coord_t w = lv_obj_get_width(id(clock_label));
@@ -463,3 +495,13 @@ interval:
           int ox = (time.minute * 7) % 61 - 30;
           int oy = (time.minute * 13) % 41 - 20;
           lv_obj_set_pos(id(clock_label), cx + ox - w/2, cy + oy - h/2);
+          if (id(clock_24h_enabled).state) {
+            lv_obj_add_flag(id(am_pm_label), LV_OBJ_FLAG_HIDDEN);
+          } else {
+            lv_label_set_text(id(am_pm_label), time.hour < 12 ? "AM" : "PM");
+            lv_obj_clear_flag(id(am_pm_label), LV_OBJ_FLAG_HIDDEN);
+            lv_obj_update_layout(id(am_pm_label));
+            lv_coord_t pw = lv_obj_get_width(id(am_pm_label));
+            lv_coord_t ph = lv_obj_get_height(id(am_pm_label));
+            lv_obj_set_pos(id(am_pm_label), cx + ox + w/2 - pw, cy + oy + h/2 - ph);
+          }

--- a/devices/guition-esp32-p4-jc8012p4a1/assets/fonts.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/assets/fonts.yaml
@@ -3,12 +3,19 @@
 # symbols (©, ®, ™, €, •, etc.) and typographic quotes (' ' " ") for song metadata.
 # Two content lines in each >- block: the fold produces exactly one space glyph.
 # roboto_thin300_font uses Thin weight for the clock screensaver (digits + colon only).
+# roboto_thin_ampm_font uses Thin weight for the AM/PM indicator in 12-hour mode.
 font:
   - file: "gfonts://Roboto@Thin"
     id: roboto_thin300_font
     size: 300
     bpp: 4
     glyphs: " 0123456789:"
+
+  - file: "gfonts://Roboto@Thin"
+    id: roboto_thin_ampm_font
+    size: 60
+    bpp: 4
+    glyphs: "AMP "
 
   - file: "gfonts://Roboto@Light"
     id: roboto_light88_font

--- a/devices/guition-esp32-p4-jc8012p4a1/device/lvgl.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/lvgl.yaml
@@ -2465,3 +2465,9 @@ lvgl:
                   text_font: roboto_thin300_font
                   text_color: 0xFFFFFF
                   text: "00:00"
+              - label:
+                  id: am_pm_label
+                  text_font: roboto_thin_ampm_font
+                  text_color: 0xFFFFFF
+                  text: "AM"
+                  hidden: true

--- a/devices/guition-esp32-s3-4848s040/assets/fonts.yaml
+++ b/devices/guition-esp32-s3-4848s040/assets/fonts.yaml
@@ -4,12 +4,19 @@
 # Two content lines in each >- block: the fold produces exactly one space glyph.
 # roboto56_font uses regular weight with minimal glyphs (digits + %) for the volume dial.
 # roboto_thin160_font uses Thin weight for the clock screensaver (digits + colon only).
+# roboto_thin_ampm_font uses Thin weight for the AM/PM indicator in 12-hour mode.
 font:
   - file: "gfonts://Roboto@Thin"
     id: roboto_thin160_font
     size: 160
     bpp: 4
     glyphs: " 0123456789:"
+
+  - file: "gfonts://Roboto@Thin"
+    id: roboto_thin_ampm_font
+    size: 40
+    bpp: 4
+    glyphs: "AMP "
 
   - file: "gfonts://Roboto"
     id: roboto56_font

--- a/devices/guition-esp32-s3-4848s040/device/lvgl.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/lvgl.yaml
@@ -2473,3 +2473,9 @@ lvgl:
                   text_font: roboto_thin160_font
                   text_color: 0xFFFFFF
                   text: "00:00"
+              - label:
+                  id: am_pm_label
+                  text_font: roboto_thin_ampm_font
+                  text_color: 0xFFFFFF
+                  text: "AM"
+                  hidden: true


### PR DESCRIPTION
## Summary
- Adds a **Screen Saver: 24-Hour Clock** toggle switch (exposed to Home Assistant) that switches the screensaver clock between 12-hour and 24-hour display
- When in 12-hour mode, an AM/PM label is shown alongside the clock and repositioned relative to the time label
- Adds the required AM/PM label widget and font assets to the LVGL configs for the Guition ESP32-P4 and ESP32-S3-4848S040 devices

## Test plan
- [ ] Flash a supported device and verify the screensaver clock displays correctly in 24-hour mode (default)
- [ ] Toggle the "Screen Saver: 24-Hour Clock" switch off in Home Assistant and confirm the clock switches to 12-hour format with AM/PM indicator
- [ ] Verify AM/PM label position updates correctly as the clock drifts each minute
- [ ] Confirm no regression in screensaver dim/off behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)