### PR TITLE
Fix jpeg image not fitting into DRAM.

### DIFF
--- a/components/artwork_image/jpeg_image.cpp
+++ b/components/artwork_image/jpeg_image.cpp
@@ -5,6 +5,7 @@
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "esp_heap_caps.h"
 
 #include "artwork_image.h"
 static const char *const TAG = "artwork_image.jpeg";
@@ -130,7 +131,7 @@ int HOT JpegDecoder::decode(uint8_t *buffer, size_t size) {
 
   // Allocate row buffers (raw pointers — safe across longjmp)
   size_t row_stride = static_cast<size_t>(out_w) * 3;
-  row_buffer = static_cast<uint8_t *>(malloc(row_stride));
+  row_buffer = static_cast<uint8_t *>(heap_caps_malloc(row_stride, MALLOC_CAP_8BIT));
   if (row_buffer == nullptr) {
     ESP_LOGE(TAG, "JPEG row buffer allocation failed: %zu bytes", row_stride);
     jpeg_destroy_decompress(&cinfo);


### PR DESCRIPTION
When playing music though Spotify Connect I got the following error (I was including the "artwork_image" part in an espcontrol fork that I made, not sure if it happens when using the esphome-media-player project directly). But the image from Spotify seems to be too big:

```
[14:58:35.202][I][mp_screensaver:324]: Fetching artwork: https://i.scdn.co/image/ab67616d0000b273cf1fee2a55e98e22bf358512
[14:58:35.202][I][artwork_image:204]: Updating image https://i.scdn.co/image/ab67616d0000b273cf1fee2a55e98e22bf358512
[14:58:35.211][D][artwork_image:841]: State request-start            url_len=64 http=0/0 dl_buf=0/169032 image=480x480 decode=0x0 retired=1 heap_free=6542400 heap_largest=6291456 pending=no
[14:58:36.073][D][http_request.idf:044]: Received response header, name: content-type, value: image/jpeg
[14:58:36.100][D][artwork_image:841]: State response-ready           url_len=64 http=0/61782 dl_buf=0/169032 image=480x480 decode=0x0 retired=1 heap_free=6505612 heap_largest=6291456 pending=no
[14:58:36.101][D][artwork_image:274]: Starting download
[14:58:36.105][D][http_request:028]: Header with name content-type found with value image/jpeg
[14:58:36.105][D][artwork_image:612]: Detected JPEG from Content-Type: image/jpeg
[14:58:36.105][D][artwork_image:728]: Allocating JPEG decoder
[14:58:36.105][D][artwork_image:841]: State decoder-ready            url_len=64 http=0/61782 dl_buf=0/169032 image=480x480 decode=0x0 retired=1 heap_free=6500604 heap_largest=6291456 pending=no
[14:58:36.111][I][artwork_image:295]: Downloading image (Size: 61782)
[14:58:36.371][D][artwork_image.jpeg:050]: JPEG decode start: 61782 bytes
[14:58:36.375][D][artwork_image.jpeg:079]: JPEG header: 640x640, components=3, progressive=no
[14:58:36.375][D][artwork_image:173]: Allocating decode buffer of 460800 bytes
[14:58:36.380][E][artwork_image.jpeg:135]: JPEG row buffer allocation failed: 1920 bytes
[14:58:36.380][E][artwork_image:502]: Error when decoding image.
```
This change was made by Claude, and I confirmed that it works, it explained the following: `MALLOC_CAP_8BIT allows fallback to PSRAM when internal DRAM is too fragmented. The existing free(row_buffer) calls work correctly for both DRAM and PSRAM allocations`.

So I have no clue if there are unintended side effects, for me on my devices that does not matter much so I did not look further, so keep that in mind before considering applying it in the public project.

-Tim