### PR TITLE
Add Wi-Fi setup via Improv Wi-Fi

### DIFF
--- a/devices/guition-esp32-s3-4848s040/esphome.yaml
+++ b/devices/guition-esp32-s3-4848s040/esphome.yaml
@@ -10,9 +10,7 @@ esphome:
   friendly_name: ${friendly_name}
 
 # Wifi Setup
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
+improv_serial:
 
 # Packages
 packages:


### PR DESCRIPTION
Fixes #25 for one device, as example.

Video:

https://github.com/user-attachments/assets/7f51fcb2-0e82-4722-b28d-8be31029bc88

- Demo: http://paulusschoutsen.nl/esp-media-player-improv-demo/
- Source of demo: https://github.com/balloob/esp-media-player-improv-demo/tree/main

Used ESPHome config:
```yaml
substitutions:
  name: "music-dashboard"
  friendly_name: "Music Dashboard"

packages:
  music_dashboard:
    url: https://github.com/jtenniswood/esphome-media-player
    files: [devices/guition-esp32-s3-4848s040/packages.yaml]
    ref: main
    refresh: 1s

improv_serial:
```