### PR TITLE
Fix ESPHome 2026.6.2 MIPI RGB compile

### DIFF
--- a/components/mipi_rgb/display.py
+++ b/components/mipi_rgb/display.py
@@ -94,6 +94,11 @@ for module_info in pkgutil.iter_modules(models.__path__):
 MODELS = DriverChip.get_models()
 
 
+def model_dimensions(config, model):
+    dimensions = model.get_dimensions(config)
+    return dimensions[0], dimensions[1]
+
+
 def data_pin_validate(value):
     """
     It is safe to use strapping pins as RGB output data bits, as they are outputs only,
@@ -256,7 +261,7 @@ FINAL_VALIDATE_SCHEMA = _final_validate
 
 async def to_code(config):
     model = MODELS[config[CONF_MODEL].upper()]
-    width, height, _offset_width, _offset_height = model.get_dimensions(config)
+    width, height = model_dimensions(config, model)
     var = cg.new_Pvariable(config[CONF_ID], width, height)
     cg.add(var.set_model(model.name))
     if enable_pin := config.get(CONF_ENABLE_PIN):

--- a/devices/esp32-p4-86-panel/dev.yaml
+++ b/devices/esp32-p4-86-panel/dev.yaml
@@ -12,5 +12,5 @@ packages:
 external_components:
   - source:
       type: local
-      path: ../components
-    components: [artwork_image]
+      path: ../../components
+    components: [artwork_image, mipi_rgb]

--- a/devices/guition-esp32-p4-jc1060p470/dev.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/dev.yaml
@@ -14,5 +14,5 @@ packages:
 external_components:
   - source:
       type: local
-      path: ../components
-    components: [artwork_image]
+      path: ../../components
+    components: [artwork_image, mipi_rgb]

--- a/devices/guition-esp32-p4-jc4880p443/dev.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/dev.yaml
@@ -14,5 +14,5 @@ packages:
 external_components:
   - source:
       type: local
-      path: ../components
-    components: [artwork_image]
+      path: ../../components
+    components: [artwork_image, mipi_rgb]

--- a/devices/guition-esp32-p4-jc8012p4a1/dev.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/dev.yaml
@@ -14,5 +14,5 @@ packages:
 external_components:
   - source:
       type: local
-      path: ../components
-    components: [artwork_image]
+      path: ../../components
+    components: [artwork_image, mipi_rgb]


### PR DESCRIPTION
## Summary
- handle ESPHome 2026.6.2 MIPI dimension tuples with extra values
- keep using only the width and height required by the display constructor
- fix P4 dev package local component paths so local package compiles exercise this branch's components

## Testing
- esphome version -> 2026.6.2
- esphome config devices/*/dev.yaml
- esphome compile devices/esp32-p4-86-panel/dev.yaml
- esphome compile devices/guition-esp32-p4-jc1060p470/dev.yaml
- esphome compile devices/guition-esp32-p4-jc4880p443/dev.yaml
- esphome compile devices/guition-esp32-p4-jc8012p4a1/dev.yaml
- esphome compile devices/guition-esp32-s3-4848s040/dev.yaml

Fixes #110