### PR TITLE
Make track info duration a dropdown

### DIFF
--- a/common/device/linked_sensors.yaml
+++ b/common/device/linked_sensors.yaml
@@ -35,12 +35,8 @@ text_sensor:
           condition:
             lambda: 'return !id(web_settings_active) && id(is_tv_mode);'
           then:
-            - if:
-                condition:
-                  lambda: 'return id(track_info_duration).state > 0 || !id(auto_show_track_info).state;'
-                then:
-                  - script.execute: show_track_view
-                  - script.stop: start_hide_track_info_timer
+            - script.execute: show_track_view
+            - script.stop: start_hide_track_info_timer
             - lvgl.widget.hide: artwork_error_label
             - lvgl.label.update:
                 id: media_title_label

--- a/common/device/sensors.yaml
+++ b/common/device/sensors.yaml
@@ -302,12 +302,8 @@ text_sensor:
           condition:
             lambda: 'return !id(web_settings_active) && !id(is_tv_mode) && !x.empty();'
           then:
-            - if:
-                condition:
-                  lambda: 'return id(track_info_duration).state > 0 || !id(auto_show_track_info).state;'
-                then:
-                  - script.execute: show_track_view
-                  - script.stop: start_hide_track_info_timer
+            - script.execute: show_track_view
+            - script.stop: start_hide_track_info_timer
             - lvgl.widget.hide: artwork_error_label
             - lvgl.label.update:
                 id: media_title_label
@@ -575,7 +571,7 @@ sensor:
 # USER-CONFIGURABLE SETTINGS (exposed to Home Assistant)
 # -----------------------------------------------------------------------------
 # How long track info stays visible after artwork has loaded (or playback
-# starts) before auto-hiding. 0 = never show on new track, no auto-hide timer.
+# starts) before auto-hiding. 0 = always show on new track, no auto-hide timer.
 # Tap to show again after auto-hide; then hides only on tap or new track.
 # Auto-show controls whether square displays reveal the track overlay when
 # new playback information arrives; tapping still toggles it manually.

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -30,7 +30,7 @@ Some configuration entities may also appear on the Home Assistant device page, d
 | **Track Clock** | On shows time remaining; off shows the track length. Tap the time label on the device to toggle this at any time. |
 | **Show Progress Bar** | Shows or hides the playback progress bar. |
 | **Auto-Show Track Info** | Shows track title and artist automatically when new playback information arrives. Turn this off to keep square screens focused on artwork and the progress bar; tap the screen to show or hide the info manually. Shown on the ESP32-S3 4848S040 and ESP32-P4 86 Panel. |
-| **Track Info Duration** | How long track info stays visible after artwork loads or playback starts. `0` means it does not auto-show on a new track. Shown on the ESP32-S3 4848S040 and ESP32-P4 86 Panel. |
+| **Track Info Duration** | How long track info stays visible after artwork loads or playback starts. Choose **Always** to keep track info visible and never auto-hide it. Options: Always, 3 seconds, 5 seconds, 10 seconds, 15 seconds, 20 seconds, 30 seconds, or 1 minute. Shown on the ESP32-S3 4848S040 and ESP32-P4 86 Panel. |
 
 ## Volume
 

--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -29,6 +29,7 @@
 
   var DEFAULT_SPEAKER_PANEL_TIMEOUT = 10;
   var SPEAKER_PANEL_TIMEOUT_OPTIONS = [5, 10, 20, 30, 60];
+  var TRACK_INFO_DURATION_OPTIONS = [0, 3, 5, 10, 15, 20, 30, 60];
   var S3_DEVICE_PROFILE = "guition-esp32-s3-4848s040";
   var WEB_ACTIVITY_HEARTBEAT_MS = 10000;
   var FIRMWARE_INSTALL_REFRESH_MS = 5000;
@@ -540,7 +541,7 @@
     body.appendChild(toggleField("Show Progress Bar", "show_progress_bar"));
     if (supportsTrackInfoDuration()) {
       body.appendChild(toggleField("Auto-Show Track Info", "auto_show_track_info"));
-      body.appendChild(numberField("Track Info Duration", "track_info_duration"));
+      body.appendChild(durationSelectField("Track Info Duration", "track_info_duration", TRACK_INFO_DURATION_OPTIONS, formatTrackInfoDuration));
     }
     return card("Playback", body, true);
   }
@@ -969,6 +970,11 @@
     if (n === 60) return "1 minute";
     if (n < 3600) return Math.round(n / 60) + " minutes";
     return "1 hour";
+  }
+
+  function formatTrackInfoDuration(value) {
+    var n = Number(value);
+    return n === 0 ? "Always" : formatDurationSeconds(n);
   }
 
   function rangeField(label, key) {

--- a/docs/webserver/src/app.template.js
+++ b/docs/webserver/src/app.template.js
@@ -29,6 +29,7 @@
 
   var DEFAULT_SPEAKER_PANEL_TIMEOUT = 10;
   var SPEAKER_PANEL_TIMEOUT_OPTIONS = [5, 10, 20, 30, 60];
+  var TRACK_INFO_DURATION_OPTIONS = [0, 3, 5, 10, 15, 20, 30, 60];
   var S3_DEVICE_PROFILE = "guition-esp32-s3-4848s040";
   var WEB_ACTIVITY_HEARTBEAT_MS = 10000;
   var FIRMWARE_INSTALL_REFRESH_MS = 5000;
@@ -540,7 +541,7 @@
     body.appendChild(toggleField("Show Progress Bar", "show_progress_bar"));
     if (supportsTrackInfoDuration()) {
       body.appendChild(toggleField("Auto-Show Track Info", "auto_show_track_info"));
-      body.appendChild(numberField("Track Info Duration", "track_info_duration"));
+      body.appendChild(durationSelectField("Track Info Duration", "track_info_duration", TRACK_INFO_DURATION_OPTIONS, formatTrackInfoDuration));
     }
     return card("Playback", body, true);
   }
@@ -969,6 +970,11 @@
     if (n === 60) return "1 minute";
     if (n < 3600) return Math.round(n / 60) + " minutes";
     return "1 hour";
+  }
+
+  function formatTrackInfoDuration(value) {
+    var n = Number(value);
+    return n === 0 ? "Always" : formatDurationSeconds(n);
   }
 
   function rangeField(label, key) {


### PR DESCRIPTION
## Summary
- Change Track Info Duration in the web settings UI from a number field to a dropdown.
- Add options for Always, 3, 5, 10, 15, 20, 30, and 60 seconds.
- Make Always keep track info visible on new track info without starting the hide timer.

## Checks
- npm run check:generated