### PR TITLE
Set track progress bar height to 4px

### DIFF
--- a/devices/esp32-p4-86-panel/device/lvgl.yaml
+++ b/devices/esp32-p4-86-panel/device/lvgl.yaml
@@ -191,7 +191,7 @@ lvgl:
             align: bottom_mid
             y: 0
             width: 720
-            height: 8
+            height: 4
             bg_color: 0x000000
             bg_opa: 50%
             radius: 0

--- a/devices/guition-esp32-p4-jc8012p4a1/device/lvgl.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/lvgl.yaml
@@ -181,7 +181,7 @@ lvgl:
             align: bottom_mid
             y: 0
             width: 1280
-            height: 6
+            height: 4
             bg_color: 0x000000
             bg_opa: 100%
             radius: 0


### PR DESCRIPTION
## Summary

- Set the 86-panel track progress bar height from 8px to 4px.
- Set the 10.1-inch JC8012P4A1 track progress bar height from 6px to 4px.
- Leaves existing 4px progress bars unchanged.

## Validation

- Checked all `media_progress_bar` LVGL definitions and confirmed they now use 4px/4.
- No firmware compile was run for this visual-only YAML sizing change.