### PR TITLE
Fix S3 display shimmer

### DIFF
--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -149,7 +149,7 @@ psram:
 # The display backlight is controlled via PWM (pulse width modulation).
 # This allows dimming the screen brightness from 0-100%.
 # - pin: GPIO38 controls the backlight
-# - frequency: 150Hz PWM frequency (fast enough to avoid flicker)
+# - frequency: 20kHz PWM frequency (above visible flicker range)
 # - min_power: Minimum brightness level (1% - prevents fully dark)
 # - zero_means_zero: When set to 0, backlight turns completely off
 #
@@ -159,7 +159,7 @@ output:
   - platform: ledc
     id: backlight_output
     pin: GPIO38
-    frequency: 150Hz
+    frequency: 20kHz
     min_power: 0.01
     zero_means_zero: true
 
@@ -746,10 +746,10 @@ display:
     model: GUITION-4848S040
     id: my_display
     color_order: RGB
-    # 6 MHz pixel clock gives the bounce buffer more headroom during LVGL
-    # full-screen flushes (e.g. new artwork). 8 MHz still works but leaves
-    # less margin and produces brief tearing marks on heavy redraws.
-    pclk_frequency: 6MHz
+    # 12 MHz is the panel vendor default and keeps the RGB refresh high enough
+    # to avoid visible shimmer. Lower clocks give more DMA margin, but can make
+    # the display look like it is pulsing, especially on static screens.
+    pclk_frequency: 12MHz
     update_interval: never
     auto_clear_enabled: False
     transform:


### PR DESCRIPTION
## Summary
- raise the 4-inch S3 backlight PWM from 150 Hz to 20 kHz to remove visible dimming flicker
- restore the S3 RGB pixel clock to the panel default 12 MHz to reduce low-refresh shimmer

## Testing
- Processing [36m[1mmedia-player[0m (board: esp32-s3-devkitc-1; framework: espidf; platform: https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip)
[1m--------------------------------------------------------------------------------[0m
[0mHARDWARE: ESP32S3 240MHz, 320KB RAM, 16MB Flash
[0m - contrib-piohome @ 3.4.4 
[0m - framework-espidf @ 3.50504.0 (5.5.4) 
[0m - tool-cmake @ 4.0.3 
[0m - tool-esp-rom-elfs @ 2024.10.11 
[0m - tool-esptoolpy @ 5.3.0 
[0m - tool-ninja @ 1.13.1 
[0m - tool-scons @ 4.40801.0 (4.8.1) 
[0m - tool-xtensa-esp-elf-gdb @ 17.1.0+20260402 
[0m - toolchain-xtensa-esp-elf @ 14.2.0+20260121
[0mReading CMake configuration...
[0mDependency Graph
[0m|-- pngle @ 1.1.0
[0m|-- Improv @ 1.2.4
[0mCompiling .pioenvs/media-player/src/main.cpp.o
[0mLinking .pioenvs/media-player/firmware.elf
[0m                            Memory Type Usage Summary                             
[0m┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Memory Type/Section ┃ Used [bytes] ┃ Used [%] ┃ Remain [bytes] ┃ Total [bytes] ┃
[0m┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ Flash Code          │      1262736 │          │                │               │
[0m│    .text            │      1262736 │          │                │               │
[0m│ Flash Data          │       907032 │          │                │               │
[0m│    .rodata          │       906776 │          │                │               │
[0m│    .appdesc         │          256 │          │                │               │
[0m│ DIRAM               │       143887 │     42.1 │         197873 │        341760 │
[0m│    .text            │        61903 │    18.11 │                │               │
[0m│    .bss             │        61624 │    18.03 │                │               │
[0m│    .data            │        20208 │     5.91 │                │               │
[0m│    .noinit          │          152 │     0.04 │                │               │
[0m│ IRAM                │        16384 │    100.0 │              0 │         16384 │
[0m│    .text            │        15356 │    93.73 │                │               │
[0m│    .vectors         │         1028 │     6.27 │                │               │
[0m└─────────────────────┴──────────────┴──────────┴────────────────┴───────────────┘
[0mRAM:   [===       ]  25.0% (used 81984 bytes from 327680 bytes)
[0mFlash: [===       ]  27.9% (used 2268007 bytes from 8126464 bytes)
[0mBuilding .pioenvs/media-player/firmware.bin
[0mCreating ESP32-S3 image...
[0mSuccessfully created ESP32-S3 image.
[0mCreating binary "firmware.factory.bin" with:
[0m    Offset   | File
[0m -  0x0      | bootloader.bin
[0m -  0x8000   | partitions.bin
[0m -  0x9000   | ota_data_initial.bin
[0m -  0x10000  | firmware.bin
Successfully created combined binary image.
[0msign_firmware([".pioenvs/media-player/firmware.bin"], [".pioenvs/media-player/firmware.elf"])
[0mmerge_factory_bin([".pioenvs/media-player/firmware.bin"], [".pioenvs/media-player/firmware.elf"])
[0mfirmware.factory.bin already created by PlatformIO - skipping merge
[0mesp32_copy_ota_bin([".pioenvs/media-player/firmware.bin"], [".pioenvs/media-player/firmware.elf"])
[0mCopied firmware to /Users/jtenniswood/Git/esphome-media-player-fix-s3-display-shimmer/builds/.esphome/build/media-player/.pioenvs/media-player/firmware.ota.bin
[0m========================= [[32m[1mSUCCESS[0m] Took 21.13 seconds =========================[0m