### PR TITLE
Increase S3 panel refresh clock

### DIFF
--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -746,10 +746,9 @@ display:
     model: GUITION-4848S040
     id: my_display
     color_order: RGB
-    # 12 MHz is the panel vendor default and keeps the RGB refresh high enough
-    # to avoid visible shimmer. Lower clocks give more DMA margin, but can make
-    # the display look like it is pulsing, especially on static screens.
-    pclk_frequency: 12MHz
+    # 16 MHz puts the panel refresh near 60 Hz with these timings, which avoids
+    # the subtle low-refresh shimmer visible at 6-12 MHz on some panels.
+    pclk_frequency: 16MHz
     update_interval: never
     auto_clear_enabled: False
     transform:


### PR DESCRIPTION
## Summary
- increase the 4-inch S3 RGB panel pixel clock from 12 MHz to 16 MHz
- targets a near-60 Hz panel refresh to reduce the remaining low-refresh shimmer after the backlight PWM fix

## Testing
- Processing [36m[1mmedia-player[0m (board: esp32-s3-devkitc-1; framework: espidf; platform: https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip)
[1m--------------------------------------------------------------------------------[0m
[0mHARDWARE: ESP32S3 240MHz, 320KB RAM, 16MB Flash
[0m - contrib-piohome @ 3.4.4 
[0m - framework-espidf @ 3.50504.0 (5.5.4) 
[0m - tool-cmake @ 4.0.3 
[0m - tool-esp-rom-elfs @ 2024.10.11 
[0m - tool-esptoolpy @ 5.3.0 
[0m - tool-ninja @ 1.13.1 
[0m - tool-scons @ 4.40801.0 (4.8.1) 
[0m - tool-xtensa-esp-elf-gdb @ 17.1.0+20260402 
[0m - toolchain-xtensa-esp-elf @ 14.2.0+20260121
[0mReading CMake configuration...
[0mDependency Graph
[0m|-- pngle @ 1.1.0
[0m|-- Improv @ 1.2.4
[0mCompiling .pioenvs/media-player/src/main.cpp.o
[0mLinking .pioenvs/media-player/firmware.elf
[0m                            Memory Type Usage Summary                             
[0m┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Memory Type/Section ┃ Used [bytes] ┃ Used [%] ┃ Remain [bytes] ┃ Total [bytes] ┃
[0m┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ Flash Code          │      1262732 │          │                │               │
[0m│    .text            │      1262732 │          │                │               │
[0m│ Flash Data          │       907032 │          │                │               │
[0m│    .rodata          │       906776 │          │                │               │
[0m│    .appdesc         │          256 │          │                │               │
[0m│ DIRAM               │       143887 │     42.1 │         197873 │        341760 │
[0m│    .text            │        61903 │    18.11 │                │               │
[0m│    .bss             │        61624 │    18.03 │                │               │
[0m│    .data            │        20208 │     5.91 │                │               │
[0m│    .noinit          │          152 │     0.04 │                │               │
[0m│ IRAM                │        16384 │    100.0 │              0 │         16384 │
[0m│    .text            │        15356 │    93.73 │                │               │
[0m│    .vectors         │         1028 │     6.27 │                │               │
[0m└─────────────────────┴──────────────┴──────────┴────────────────┴───────────────┘
[0mRAM:   [===       ]  25.0% (used 81984 bytes from 327680 bytes)
[0mFlash: [===       ]  27.9% (used 2268003 bytes from 8126464 bytes)
[0mBuilding .pioenvs/media-player/firmware.bin
[0mCreating ESP32-S3 image...
[0mSuccessfully created ESP32-S3 image.
[0mCreating binary "firmware.factory.bin" with:
[0m    Offset   | File
[0m -  0x0      | bootloader.bin
[0m -  0x8000   | partitions.bin
[0m -  0x9000   | ota_data_initial.bin
[0m -  0x10000  | firmware.bin
Successfully created combined binary image.
[0msign_firmware([".pioenvs/media-player/firmware.bin"], [".pioenvs/media-player/firmware.elf"])
[0mmerge_factory_bin([".pioenvs/media-player/firmware.bin"], [".pioenvs/media-player/firmware.elf"])
[0mfirmware.factory.bin already created by PlatformIO - skipping merge
[0mesp32_copy_ota_bin([".pioenvs/media-player/firmware.bin"], [".pioenvs/media-player/firmware.elf"])
[0mCopied firmware to /Users/jtenniswood/Git/esphome-media-player-increase-s3-panel-refresh/builds/.esphome/build/media-player/.pioenvs/media-player/firmware.ota.bin
[0m========================= [[32m[1mSUCCESS[0m] Took 41.24 seconds =========================[0m