### PR TITLE
Add rotation controls for square displays

### DIFF
--- a/devices/esp32-p4-86-panel/device/device.yaml
+++ b/devices/esp32-p4-86-panel/device/device.yaml
@@ -145,6 +145,35 @@ api:
 
 
 # -----------------------------------------------------------------------------
+# SCREEN ROTATION SELECT
+# -----------------------------------------------------------------------------
+# Exposes native LVGL display rotation to Home Assistant and the web settings UI.
+# LVGL handles the screen transform and touch input rotation together.
+# -----------------------------------------------------------------------------
+select:
+  - platform: template
+    name: "Screen Rotation"
+    id: screen_rotation_select
+    icon: "mdi:screen-rotation"
+    entity_category: config
+    internal: ${ha_config_internal}
+    optimistic: true
+    restore_value: true
+    initial_option: "${display_rotation}"
+    options:
+      - "0"
+      - "90"
+      - "180"
+      - "270"
+    on_value:
+      - if:
+          condition:
+            lambda: 'return id(lvgl_ready);'
+          then:
+            - script.execute: apply_screen_rotation
+
+
+# -----------------------------------------------------------------------------
 # LOGGING
 # -----------------------------------------------------------------------------
 # Outputs debug messages for troubleshooting.
@@ -268,6 +297,9 @@ globals:
     type: bool
     restore_value: true
     initial_value: 'false'
+  - id: lvgl_ready
+    type: bool
+    initial_value: 'false'
 
 
 
@@ -310,14 +342,22 @@ touchscreen:
       - lambda: |-
           int dx = id(touch_x_end) - id(touch_x_start);
           int dy = id(touch_y_end) - id(touch_y_start);
-          int sy = id(touch_y_start);
-          ESP_LOGD("touch", "Swipe dx=%d dy=%d start=(%d,%d) end=(%d,%d)",
-                   dx, dy, id(touch_x_start), id(touch_y_start),
+          int32_t view_x_start = id(touch_x_start);
+          int32_t view_y_start = id(touch_y_start);
+          int32_t view_x_end = id(touch_x_end);
+          int32_t view_y_end = id(touch_y_end);
+          id(main_lvgl).rotate_coordinates(view_x_start, view_y_start);
+          id(main_lvgl).rotate_coordinates(view_x_end, view_y_end);
+          int view_dx = view_x_end - view_x_start;
+          int view_dy = view_y_end - view_y_start;
+
+          ESP_LOGD("touch", "Swipe raw=(%d,%d) view=(%d,%d) rotation=%s start=(%d,%d) end=(%d,%d)",
+                   dx, dy, view_dx, view_dy, id(screen_rotation_select).current_option().c_str(), id(touch_x_start), id(touch_y_start),
                    id(touch_x_end), id(touch_y_end));
 
           // --- Dismiss actions prompt on tap ---
           if (!lv_obj_has_flag(id(actions_prompt), LV_OBJ_FLAG_HIDDEN)) {
-            if (abs(dx) < 30 && abs(dy) < 30) {
+            if (abs(view_dx) < 30 && abs(view_dy) < 30) {
               lv_obj_add_flag(id(actions_prompt), LV_OBJ_FLAG_HIDDEN);
               id(actions_prompt_acked) = true;
               id(device_has_been_setup) = true;
@@ -327,7 +367,7 @@ touchscreen:
           }
 
           // --- Long press (5 s): turn off display ---
-          if (abs(dx) < 30 && abs(dy) < 30 && !id(was_screen_dimmed)
+          if (abs(view_dx) < 30 && abs(view_dy) < 30 && !id(was_screen_dimmed)
               && (millis() - id(touch_start_time) >= 5000)) {
             id(turn_off_display).execute();
             return;
@@ -335,12 +375,12 @@ touchscreen:
 
           // --- Vertical swipe: settings panel open/close ---
           // Swipe down to open: 30px+ downward movement, panel closed
-          if (dy > 30 && abs(dy) > abs(dx) * 2 && !id(is_panel_open)) {
+          if (view_dy > 30 && abs(view_dy) > abs(view_dx) * 2 && !id(is_panel_open)) {
             id(open_settings_panel).execute();
             return;
           }
           // Swipe up to close: panel is open, but not when multi-speaker list is scrollable
-          if (dy < -90 && abs(dy) > abs(dx) * 2 && id(is_panel_open)
+          if (view_dy < -90 && abs(view_dy) > abs(view_dx) * 2 && id(is_panel_open)
               && (lv_obj_has_flag(id(speakers_container), LV_OBJ_FLAG_HIDDEN) || id(speaker_count) <= 1)) {
             id(close_settings_panel).execute();
             return;
@@ -353,7 +393,7 @@ touchscreen:
           }
 
           // --- Horizontal swipe: track navigation (works when playing or paused) ---
-          if (abs(dx) > 120 && abs(dx) > abs(dy) * 2) {
+          if (abs(view_dx) > 120 && abs(view_dx) > abs(view_dy) * 2) {
             bool can_skip = false;
             if (id(is_tv_mode)) {
               std::string e = id(linked_media_player_entity).state;
@@ -371,7 +411,7 @@ touchscreen:
               }
             }
             if (can_skip) {
-              if (dx > 0) {
+              if (view_dx > 0) {
                 id(swipe_previous_track).execute();
               } else {
                 id(swipe_next_track).execute();
@@ -382,8 +422,9 @@ touchscreen:
           // Excludes the play/pause button area (x:390-462, y:356-428).
           // If screen was dimmed, just wake it (don't hide the UI).
           // Only allow hiding the UI when media is actively playing.
-          else if (abs(dx) < 30 && abs(dy) < 30) {
-            int sx = id(touch_x_start);
+          else if (abs(view_dx) < 30 && abs(view_dy) < 30) {
+            int sx = view_x_start;
+            int sy = view_y_start;
             // Ignore taps on the play/pause button
             if (sx >= 578 && sx <= 701 && sy >= 527 && sy <= 650) {
               return;
@@ -421,6 +462,31 @@ touchscreen:
 # mode: restart – cancels the in-progress run and starts fresh
 # -----------------------------------------------------------------------------
 script:
+  # -- Apply Home Assistant/web settings screen rotation using native LVGL rotation --
+  - id: apply_screen_rotation
+    mode: restart
+    then:
+      - if:
+          condition:
+            lambda: 'return id(screen_rotation_select).current_option() == "0";'
+          then:
+            - lvgl.display.set_rotation: 0
+      - if:
+          condition:
+            lambda: 'return id(screen_rotation_select).current_option() == "90";'
+          then:
+            - lvgl.display.set_rotation: 90
+      - if:
+          condition:
+            lambda: 'return id(screen_rotation_select).current_option() == "180";'
+          then:
+            - lvgl.display.set_rotation: 180
+      - if:
+          condition:
+            lambda: 'return id(screen_rotation_select).current_option() == "270";'
+          then:
+            - lvgl.display.set_rotation: 270
+
   # -- Toggle now-playing overlay (fade in / fade out) --
   - id: toggle_ui
     mode: restart

--- a/devices/esp32-p4-86-panel/device/lvgl.yaml
+++ b/devices/esp32-p4-86-panel/device/lvgl.yaml
@@ -6,6 +6,7 @@
 # =============================================================================
 
 lvgl:
+  id: main_lvgl
   buffer_size: 100%
   displays: my_display
   byte_order: little_endian
@@ -24,6 +25,8 @@ lvgl:
         #else
         if (indev) indev->driver->scroll_limit = 20;
         #endif
+    - lambda: 'id(lvgl_ready) = true;'
+    - script.execute: apply_screen_rotation
 
   pages:
     - id: main_page

--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -119,6 +119,35 @@ api:
 
 
 # -----------------------------------------------------------------------------
+# SCREEN ROTATION SELECT
+# -----------------------------------------------------------------------------
+# Exposes native LVGL display rotation to Home Assistant and the web settings UI.
+# LVGL handles the screen transform and touch input rotation together.
+# -----------------------------------------------------------------------------
+select:
+  - platform: template
+    name: "Screen Rotation"
+    id: screen_rotation_select
+    icon: "mdi:screen-rotation"
+    entity_category: config
+    internal: ${ha_config_internal}
+    optimistic: true
+    restore_value: true
+    initial_option: "${display_rotation}"
+    options:
+      - "0"
+      - "90"
+      - "180"
+      - "270"
+    on_value:
+      - if:
+          condition:
+            lambda: 'return id(lvgl_ready);'
+          then:
+            - script.execute: apply_screen_rotation
+
+
+# -----------------------------------------------------------------------------
 # LOGGING
 # -----------------------------------------------------------------------------
 # Outputs debug messages for troubleshooting.
@@ -254,6 +283,9 @@ globals:
     type: bool
     restore_value: true
     initial_value: 'false'
+  - id: lvgl_ready
+    type: bool
+    initial_value: 'false'
 
 
 
@@ -311,8 +343,8 @@ touchscreen:
           int view_dx = view_x_end - view_x_start;
           int view_dy = view_y_end - view_y_start;
 
-          ESP_LOGD("touch", "Swipe raw=(%d,%d) view=(%d,%d) rotation=${display_rotation} start=(%d,%d) end=(%d,%d)",
-                   dx, dy, view_dx, view_dy, id(touch_x_start), id(touch_y_start),
+          ESP_LOGD("touch", "Swipe raw=(%d,%d) view=(%d,%d) rotation=%s start=(%d,%d) end=(%d,%d)",
+                   dx, dy, view_dx, view_dy, id(screen_rotation_select).current_option().c_str(), id(touch_x_start), id(touch_y_start),
                    id(touch_x_end), id(touch_y_end));
 
           // --- Dismiss actions prompt on tap ---
@@ -422,6 +454,31 @@ touchscreen:
 # mode: restart – cancels the in-progress run and starts fresh
 # -----------------------------------------------------------------------------
 script:
+  # -- Apply Home Assistant/web settings screen rotation using native LVGL rotation --
+  - id: apply_screen_rotation
+    mode: restart
+    then:
+      - if:
+          condition:
+            lambda: 'return id(screen_rotation_select).current_option() == "0";'
+          then:
+            - lvgl.display.set_rotation: 0
+      - if:
+          condition:
+            lambda: 'return id(screen_rotation_select).current_option() == "90";'
+          then:
+            - lvgl.display.set_rotation: 90
+      - if:
+          condition:
+            lambda: 'return id(screen_rotation_select).current_option() == "180";'
+          then:
+            - lvgl.display.set_rotation: 180
+      - if:
+          condition:
+            lambda: 'return id(screen_rotation_select).current_option() == "270";'
+          then:
+            - lvgl.display.set_rotation: 270
+
   # -- Toggle now-playing overlay (fade in / fade out) --
   - id: toggle_ui
     mode: restart

--- a/devices/guition-esp32-s3-4848s040/device/lvgl.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/lvgl.yaml
@@ -31,6 +31,8 @@ lvgl:
         #else
         if (indev) indev->driver->scroll_limit = 20;
         #endif
+    - lambda: 'id(lvgl_ready) = true;'
+    - script.execute: apply_screen_rotation
 
   pages:
     - id: main_page

--- a/docs/advanced/display-rotation.md
+++ b/docs/advanced/display-rotation.md
@@ -5,7 +5,7 @@ description: Rotate supported ESPHome Media Player touchscreen displays and touc
 
 # Display Rotation
 
-Supported devices can rotate the display for different mounting orientations (for example to change which side the power cable exits from). Set `display_rotation` to rotate both the screen and touch input.
+Supported devices can rotate the display for different mounting orientations (for example to change which side the power cable exits from). Set `display_rotation` in YAML, or use **Screen Rotation** from the device web settings page on supported firmware, to rotate both the screen and touch input.
 
 ::: warning
 ESPHome 2026.4 and newer handle rotation through LVGL (`lvgl.rotation`), including touch input. Older examples that set `touch_swap_xy`, `touch_mirror_x`, or `touch_mirror_y` are no longer needed.
@@ -21,6 +21,8 @@ The 480×480 square display supports all four rotations.
 | `"90"`              |
 | `"180"`             |
 | `"270"`             |
+
+The device also exposes **Screen Rotation** in the web settings page and Home Assistant.
 
 ### Example: 90-degree rotation
 
@@ -72,6 +74,8 @@ The 720x720 square display supports the same four rotations as the S3 square dis
 | `"90"` |
 | `"180"` |
 | `"270"` |
+
+The device also exposes **Screen Rotation** in the web settings page.
 
 Example:
 

--- a/docs/devices/esp32-p4-86-panel.md
+++ b/docs/devices/esp32-p4-86-panel.md
@@ -19,6 +19,10 @@ Click **Install** to flash the firmware directly from your browser. No ESPHome d
 If you prefer to install via the ESPHome dashboard, see [ESPHome Config](/advanced/esphome-config) (this device uses the `devices/esp32-p4-86-panel` package).
 :::
 
+## Rotation
+
+Use **Screen Rotation** in the device web settings page to rotate the display and touch input together. The supported values are `0`, `90`, `180`, and `270`.
+
 ## Where to Buy
 
 - **Panel:** [Waveshare](https://www.waveshare.com/esp32-p4-wifi6-touch-lcd-4b.htm)

--- a/docs/devices/esp32-s3-4848s040.md
+++ b/docs/devices/esp32-s3-4848s040.md
@@ -24,6 +24,10 @@ Click **Install** to flash the firmware directly from your browser. No ESPHome d
 If you prefer to install via the ESPHome dashboard, see [ESPHome Config](/advanced/esphome-config) (this device uses the `devices/guition-esp32-s3-4848s040` package).
 :::
 
+## Rotation
+
+Use **Screen Rotation** in the device web settings page or Home Assistant to rotate the display and touch input together. The supported values are `0`, `90`, `180`, and `270`.
+
 ## Gallery
 
 ![Guition ESP32-S3 4848S040 media controller with playback controls](../images/guition-esp32-s3-4848s040-example2.jpg)

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -105,7 +105,7 @@ Shifts album art toward warmer colors for a more comfortable viewing experience,
 | **Day Screen Warmth** | Warmth applied to album art during the day. 0% = no tint, 100% = maximum warmth. Default: 30%. |
 | **Night Screen Warmth** | Warmth applied to album art at night. 0% = no tint, 100% = maximum warmth. Default: 60%. |
 
-## Rotation <Badge type="info" text="supported P4 panels" />
+## Rotation <Badge type="info" text="supported panels" />
 
 | Setting | Description |
 |---------|-------------|

--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -762,7 +762,7 @@
   }
 
   function supportsScreenRotation() {
-    return S.device_profile === "guition-esp32-p4-jc4880p443" || S.device_profile === "guition-esp32-p4-jc1060p470" || S.device_profile === "guition-esp32-p4-jc8012p4a1";
+    return S.device_profile === "esp32-p4-86-panel" || S.device_profile === "guition-esp32-p4-jc4880p443" || S.device_profile === "guition-esp32-p4-jc1060p470" || S.device_profile === "guition-esp32-p4-jc8012p4a1" || S.device_profile === "guition-esp32-s3-4848s040";
   }
 
   function supportsClockScreenSaver() {

--- a/docs/webserver/src/app.template.js
+++ b/docs/webserver/src/app.template.js
@@ -762,7 +762,7 @@
   }
 
   function supportsScreenRotation() {
-    return S.device_profile === "guition-esp32-p4-jc4880p443" || S.device_profile === "guition-esp32-p4-jc1060p470" || S.device_profile === "guition-esp32-p4-jc8012p4a1";
+    return S.device_profile === "esp32-p4-86-panel" || S.device_profile === "guition-esp32-p4-jc4880p443" || S.device_profile === "guition-esp32-p4-jc1060p470" || S.device_profile === "guition-esp32-p4-jc8012p4a1" || S.device_profile === "guition-esp32-s3-4848s040";
   }
 
   function supportsClockScreenSaver() {


### PR DESCRIPTION
## Summary

- Add a Screen Rotation select for the Guition ESP32-S3 4848S040 so users can rotate the display and touch input after flashing.
- Add the same rotation control and rotation-aware swipe handling for the ESP32-P4 86 Panel square display.
- Show the rotation control in the web settings UI for both square panels and update the public docs.

Fixes #118.

## Validation

- `npm run check:all`
- `esphome config builds/guition-esp32-s3-4848s040.yaml`
- `esphome config builds/esp32-p4-86-panel.yaml`
- `esphome compile builds/guition-esp32-s3-4848s040.yaml`
- `esphome compile builds/esp32-p4-86-panel.yaml`

## Documentation decision

- [x] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [ ] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Updated the square-panel device pages, display rotation guide, settings reference, and generated web settings bundle.
