### PR TITLE
Stabilize JC8012P4A1 touchscreen startup

### DIFF
--- a/components/gsl3680/gsl3680.cpp
+++ b/components/gsl3680/gsl3680.cpp
@@ -35,13 +35,37 @@ esphome::i2c::ErrorCode GSL3680::init() {
     auto err = esphome::i2c::ERROR_OK;
 
     STOP_ON_I2C_ERROR(err, this->read_configuration());
-    STOP_ON_I2C_ERROR(err, this->clear_registers());
-    STOP_ON_I2C_ERROR(err, this->reset());
-    STOP_ON_I2C_ERROR(err, this->load_firmware());
-    STOP_ON_I2C_ERROR(err, this->start());
-    STOP_ON_I2C_ERROR(err, this->read_ram());
+
+    for (uint8_t attempt = 1; attempt <= 2; attempt++) {
+        STOP_ON_I2C_ERROR(err, this->clear_registers());
+        STOP_ON_I2C_ERROR(err, this->reset());
+        STOP_ON_I2C_ERROR(err, this->load_firmware());
+        STOP_ON_I2C_ERROR(err, this->start());
+
+        err = this->read_ram();
+        if (err == esphome::i2c::ERROR_OK) {
+            return err;
+        }
+
+        if (attempt < 2) {
+            ESP_LOGW(TAG, "Startup status check failed; power-cycling touchscreen and retrying firmware load");
+            this->power_cycle();
+        }
+    }
 
     return err;
+}
+
+void GSL3680::power_cycle() {
+    this->reset_pin_->digital_write(false);
+    esphome::delay(50);
+    this->reset_pin_->digital_write(true);
+    esphome::delay(30);
+    this->reset_pin_->digital_write(false);
+    esphome::delay(5);
+    this->reset_pin_->digital_write(true);
+    esphome::delay(20);
+    ESP_LOGD(TAG, "Power cycle complete");
 }
 
 esphome::i2c::ErrorCode GSL3680::reset() {
@@ -95,8 +119,8 @@ esphome::i2c::ErrorCode GSL3680::read_configuration() {
 }
 
 esphome::i2c::ErrorCode GSL3680::clear_registers() {
-    uint8_t clear_reg_regs[4] = {0xe0, 0x88, 0xe4, 0xe0};
-    uint8_t clear_reg_data[4] = {0x88, 0x01, 0x04, 0x00};
+    uint8_t clear_reg_regs[4] = {0xe0, 0x80, 0xe4, 0xe0};
+    uint8_t clear_reg_data[4] = {0x88, TOUCH_MAX_POINTS, 0x04, 0x00};
 
     auto err = esphome::i2c::ERROR_OK;
 

--- a/components/gsl3680/gsl3680.h
+++ b/components/gsl3680/gsl3680.h
@@ -40,6 +40,7 @@ class GSL3680 : public touchscreen::Touchscreen, public i2c::I2CDevice {
         esphome::i2c::ErrorCode load_firmware();
         esphome::i2c::ErrorCode start();
         esphome::i2c::ErrorCode read_ram();
+        void power_cycle();
 };
 
 }

--- a/devices/guition-esp32-p4-jc8012p4a1/dev.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/dev.yaml
@@ -15,4 +15,4 @@ external_components:
   - source:
       type: local
       path: ../../components
-    components: [artwork_image, mipi_rgb]
+    components: [artwork_image, gsl3680, mipi_rgb]


### PR DESCRIPTION
## Summary
- retry the GSL3680 firmware startup once after a failed 0x5a status check
- power-cycle the touchscreen between retry attempts
- align the startup register setup with the Silead driver
- include gsl3680 in the JC8012P4A1 dev config local component override

Fixes #117

## Validation
- ESPHome 2026.6.4 config check for devices/guition-esp32-p4-jc8012p4a1/dev.yaml
- ESPHome 2026.6.4 compile for devices/guition-esp32-p4-jc8012p4a1/dev.yaml
- Confirmed generated source contains the new GSL3680 retry path and corrected startup register

Note: Docker compile with ESPHome 2026.6.2 could not complete because Docker ran out of local disk space while installing the ESP32-P4 compiler, before compiling project source.