### PR TITLE
Fix Guition S3 black screen after touch

### DIFF
--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -27,6 +27,10 @@ esp32:
   watchdog_timeout: 15s
   framework:
     type: esp-idf
+    sdkconfig_options:
+      # The S3 RGB panel scans from PSRAM while LVGL and artwork decoding also
+      # use PSRAM. Recover the LCD DMA at VSYNC if that stream stalls.
+      CONFIG_LCD_RGB_RESTART_IN_VSYNC: "y"
 
 
 # -----------------------------------------------------------------------------
@@ -746,9 +750,9 @@ display:
     model: GUITION-4848S040
     id: my_display
     color_order: RGB
-    # 16 MHz puts the panel refresh near 60 Hz with these timings, which avoids
-    # the subtle low-refresh shimmer visible at 6-12 MHz on some panels.
-    pclk_frequency: 16MHz
+    # 12 MHz is the Guition model default and leaves more DMA margin during
+    # touch-triggered LVGL redraws on ESPHome 2026.6.
+    pclk_frequency: 12MHz
     update_interval: never
     auto_clear_enabled: False
     transform:


### PR DESCRIPTION
## Summary

- Restore ESP-IDF VSYNC restart recovery for the Guition ESP32-S3 4848S040 RGB panel.
- Move the S3 panel pixel clock back to the Guition/ESPHome default of 12 MHz to leave more DMA margin during LVGL redraws.

## Why

Issue #119 reports the S3 screen going black after touch on ESPHome 2026.6 while touch input continues to work. That points to the RGB display stream stalling rather than the device or touchscreen failing.

Fixes #119.

## Testing

- Compiled `builds/guition-esp32-s3-4848s040.factory.yaml` with `ghcr.io/esphome/esphome:2026.6.4`.
- Firmware compile completed successfully and produced factory/OTA binaries.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- This is a firmware stability fix for the existing Guition S3 display behavior. Users do not need a new setting or different setup instructions.
