### PR TITLE
Update ESPHome to 2026.6.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  ESPHOME_VERSION: 2026.5.1
+  ESPHOME_VERSION: 2026.6.4
 
 jobs:
   release-notes:

--- a/devices/esp32-p4-86-panel/device/device.yaml
+++ b/devices/esp32-p4-86-panel/device/device.yaml
@@ -24,7 +24,7 @@ esp32:
   flash_size: 32MB
   cpu_frequency: 360MHz
   # Current Waveshare 4" P4 panels report ESP-ROM:esp32p4-eco2 in the boot log.
-  # ESPHome 2026.4 defaults P4 builds to production rev3 silicon unless this is set.
+  # ESPHome defaults P4 builds to production rev3 silicon unless this is set.
   engineering_sample: true
   framework:
     type: esp-idf

--- a/devices/guition-esp32-p4-jc1060p470/device/device.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/device.yaml
@@ -150,7 +150,7 @@ api:
 # -----------------------------------------------------------------------------
 # SCREEN ROTATION SELECT
 # -----------------------------------------------------------------------------
-# Exposes ESPHome 2026.4 native LVGL display rotation to Home Assistant.
+# Exposes native ESPHome LVGL display rotation to Home Assistant.
 # LVGL handles the screen transform and touch input rotation together.
 # -----------------------------------------------------------------------------
 select:

--- a/devices/guition-esp32-p4-jc1060p470/packages.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/packages.yaml
@@ -1,6 +1,6 @@
 substitutions:
-  # Native LVGL display rotation in degrees. ESPHome 2026.4 rotates touch input
-  # through LVGL too, so no GT911 transform is needed for normal rotation.
+  # Native LVGL display rotation in degrees. ESPHome rotates touch input through
+  # LVGL too, so no GT911 transform is needed for normal rotation.
   # Default is landscape with the artwork on the left.
   display_rotation: "0"
 

--- a/devices/guition-esp32-p4-jc4880p443/device/device.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/device.yaml
@@ -150,7 +150,7 @@ api:
 # -----------------------------------------------------------------------------
 # SCREEN ROTATION SELECT
 # -----------------------------------------------------------------------------
-# Exposes ESPHome 2026.4 native LVGL display rotation to Home Assistant.
+# Exposes native ESPHome LVGL display rotation to Home Assistant.
 # LVGL handles the screen transform and touch input rotation together.
 # -----------------------------------------------------------------------------
 select:

--- a/devices/guition-esp32-p4-jc4880p443/packages-90.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/packages-90.yaml
@@ -1,6 +1,6 @@
 substitutions:
   # 90-degree landscape layout preset for side-mounted JC4880P443 installs.
-  # Rotation itself is handled by native LVGL rotation in ESPHome 2026.4.
+  # Rotation itself is handled by native ESPHome LVGL rotation.
   display_rotation: "90"
 
   # Device profile

--- a/devices/guition-esp32-p4-jc4880p443/packages.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/packages.yaml
@@ -1,6 +1,6 @@
 substitutions:
-  # Native LVGL display rotation in degrees. ESPHome 2026.4 rotates touch input
-  # through LVGL too, so no GT911 transform is needed for normal rotation.
+  # Native LVGL display rotation in degrees. ESPHome rotates touch input through
+  # LVGL too, so no GT911 transform is needed for normal rotation.
   # Default is portrait with the artwork at the top.
   display_rotation: "0"
 

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -126,7 +126,7 @@ api:
 # -----------------------------------------------------------------------------
 # SCREEN ROTATION SELECT
 # -----------------------------------------------------------------------------
-# Exposes ESPHome 2026.4 native LVGL display rotation to Home Assistant.
+# Exposes native ESPHome LVGL display rotation to Home Assistant.
 # LVGL handles the screen transform and touch input rotation together.
 # -----------------------------------------------------------------------------
 select:

--- a/devices/guition-esp32-p4-jc8012p4a1/packages.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/packages.yaml
@@ -1,6 +1,6 @@
 substitutions:
-  # Native LVGL display rotation in degrees. ESPHome 2026.4 rotates touch input
-  # through LVGL too. 90 is the default landscape layout; 0/180 use portrait.
+  # Native LVGL display rotation in degrees. ESPHome rotates touch input through
+  # LVGL too. 90 is the default landscape layout; 0/180 use portrait.
   display_rotation: "90"
 
   # Device profile

--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -21,9 +21,9 @@
 esp32:
   board: esp32-s3-devkitc-1
   flash_size: 16MB
-  # ESPHome 2026.5 tightened the ESP32 idle/watchdog timing. This display can
-  # briefly block while LVGL and artwork buffers are busy, so keep watchdog
-  # protection enabled but allow the same 15s window ESPHome uses for OTA.
+  # ESPHome's ESP32 idle/watchdog timing can be tight while this display briefly
+  # blocks on LVGL and artwork buffers, so keep watchdog protection enabled but
+  # allow the same 15s window ESPHome uses for OTA.
   watchdog_timeout: 15s
   framework:
     type: esp-idf

--- a/docs/advanced/display-rotation.md
+++ b/docs/advanced/display-rotation.md
@@ -8,7 +8,7 @@ description: Rotate supported ESPHome Media Player touchscreen displays and touc
 Supported devices can rotate the display for different mounting orientations (for example to change which side the power cable exits from). Set `display_rotation` to rotate both the screen and touch input.
 
 ::: warning
-ESPHome 2026.4 and newer handle rotation through LVGL (`lvgl.rotation`), including touch input. Older examples that set `touch_swap_xy`, `touch_mirror_x`, or `touch_mirror_y` are no longer needed.
+Current ESPHome releases handle rotation through LVGL (`lvgl.rotation`), including touch input. Older examples that set `touch_swap_xy`, `touch_mirror_x`, or `touch_mirror_y` are no longer needed.
 :::
 
 ## ESP32-S3 4848S040

--- a/docs/advanced/esphome-config.md
+++ b/docs/advanced/esphome-config.md
@@ -9,7 +9,7 @@ Install the media player firmware via the ESPHome dashboard instead of the web i
 
 ## Prerequisites
 
-- [ESPHome](https://esphome.io/) 2026.4 or newer running (as a Home Assistant add-on or standalone)
+- [ESPHome](https://esphome.io/) 2026.6.4 or newer running (as a Home Assistant add-on or standalone)
 - Your device connected via USB for the first flash (OTA updates work after that)
 
 ## Create a configuration

--- a/docs/devices/esp32-p4-jc1060p470.md
+++ b/docs/devices/esp32-p4-jc1060p470.md
@@ -29,7 +29,7 @@ This device should be tested on real hardware after flashing. If touch input is 
 
 ## Display Rotation
 
-The device exposes **Screen Rotation** in Home Assistant as a dropdown with `0`, `90`, `180`, and `270` options. This uses ESPHome 2026.4's native LVGL rotation, including touch rotation.
+The device exposes **Screen Rotation** in Home Assistant as a dropdown with `0`, `90`, `180`, and `270` options. This uses ESPHome's native LVGL rotation, including touch rotation.
 
 The default view is landscape at `0`. Use `180` to flip the landscape layout, or `90`/`270` for portrait mounting.
 

--- a/docs/devices/esp32-p4-jc4880p443.md
+++ b/docs/devices/esp32-p4-jc4880p443.md
@@ -27,7 +27,7 @@ This device should be tested on real hardware after flashing. If touch input is 
 
 ## Display Rotation
 
-The device exposes **Screen Rotation** in Home Assistant as a dropdown with `0`, `90`, `180`, and `270` options. This uses ESPHome 2026.4's native LVGL rotation, including touch rotation.
+The device exposes **Screen Rotation** in Home Assistant as a dropdown with `0`, `90`, `180`, and `270` options. This uses ESPHome's native LVGL rotation, including touch rotation.
 
 The default package is the landscape layout with `display_rotation` set to `90`. Use `270` if your landscape mount is upside down:
 


### PR DESCRIPTION
## Summary
- Update the release workflow ESPHome Docker image pin from 2026.5.1 to 2026.6.4.
- Update the manual ESPHome setup prerequisite to 2026.6.4 or newer.
- Remove stale older ESPHome version wording from rotation/watchdog comments and docs while keeping compatibility guards unchanged.

## Verification
- Confirmed ghcr.io/esphome/esphome:2026.6.4 exists.
- npm run docs:build
- ESPHome 2026.6.4 factory compile passed for:
  - guition-esp32-s3-4848s040
  - guition-esp32-p4-jc1060p470
  - guition-esp32-p4-jc4880p443
  - guition-esp32-p4-jc8012p4a1
  - esp32-p4-86-panel
