### PR TITLE
Use Home Assistant timezone by default

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -430,9 +430,6 @@ script:
             return;
           }
 
-          id(ha_time).set_timezone(id(tz_posix));
-          setenv("TZ", id(tz_posix).c_str(), 1);
-          tzset();
           auto now = id(ha_time).now();
           if (!now.is_valid()) return;
 
@@ -488,9 +485,6 @@ script:
       - lambda: |-
           if (!id(schedule_enabled).state || id(screen_schedule_manual_wake_ms) == 0) return;
 
-          id(ha_time).set_timezone(id(tz_posix));
-          setenv("TZ", id(tz_posix).c_str(), 1);
-          tzset();
           auto now = id(ha_time).now();
           if (!now.is_valid()) return;
 
@@ -573,9 +567,6 @@ script:
       - lambda: |-
           if (!id(schedule_enabled).state) return;
 
-          id(ha_time).set_timezone(id(tz_posix));
-          setenv("TZ", id(tz_posix).c_str(), 1);
-          tzset();
           auto now = id(ha_time).now();
           if (!now.is_valid()) return;
 
@@ -782,9 +773,6 @@ script:
       - lambda: |-
           if (!id(is_clock_showing)) return;
           if (lv_obj_has_flag(id(clock_screensaver), LV_OBJ_FLAG_HIDDEN)) return;
-          id(ha_time).set_timezone(id(tz_posix));
-          setenv("TZ", id(tz_posix).c_str(), 1);
-          tzset();
           auto time = id(ha_time).now();
           int minute = 0;
           if (time.is_valid()) {

--- a/common/addon/time.yaml
+++ b/common/addon/time.yaml
@@ -2,7 +2,6 @@
 time:
   - platform: homeassistant
     id: ha_time
-    timezone: UTC0
     on_time:
       - seconds: 0
         minutes: '*'

--- a/common/addon/timezone.yaml
+++ b/common/addon/timezone.yaml
@@ -1,9 +1,10 @@
 # =============================================================================
 # CLOCK TIMEZONE
 # =============================================================================
-# Matches the espcontrol timezone selector: values are IANA-style timezone
-# names with a simple GMT hint. The browser can display the current GMT
-# offset, while firmware maps the selected timezone to a POSIX TZ string.
+# Defaults to Home Assistant's timezone sync. Manual options match the
+# espcontrol timezone selector: values are IANA-style timezone names with a
+# simple GMT hint. The browser can display the current GMT offset, while
+# firmware maps the selected timezone to a POSIX TZ string.
 # =============================================================================
 
 
@@ -39,8 +40,9 @@ select:
     internal: ${ha_config_internal}
     optimistic: true
     restore_value: true
-    initial_option: "UTC (GMT+0)"
+    initial_option: "Home Assistant (automatic)"
     options:
+      - "Home Assistant (automatic)"
       - "Pacific/Midway (GMT-11)"
       - "Pacific/Pago_Pago (GMT-11)"
       - "Pacific/Honolulu (GMT-10)"
@@ -377,6 +379,12 @@ script:
           };
           std::string sel = id(clock_timezone).current_option();
           if (sel.empty()) return;
+
+          if (sel == "Home Assistant (automatic)") {
+            id(tz_posix) = "";
+            ESP_LOGI("timezone", "Using Home Assistant timezone");
+            return;
+          }
 
           size_t hint = sel.find(" (");
           std::string tz_id = hint == std::string::npos ? sel : sel.substr(0, hint);

--- a/docs/features/screen-saver.md
+++ b/docs/features/screen-saver.md
@@ -76,7 +76,7 @@ This is useful when you want day/night to depend on more than just the sun — f
 | **Day Clock Brightness** | Backlight level for the daytime clock screen saver. | 35% |
 | **Evening Clock Brightness** | Backlight level for the evening clock screen saver. | 35% |
 | **Clock Format** | Clock display format: 24-hour or 12-hour without AM/PM. | 24 Hour |
-| **Timezone** | IANA-style timezone for the clock and scheduled screen-off controls. The browser shows the current GMT offset. | UTC |
+| **Timezone** | Defaults to Home Assistant's timezone for the clock and scheduled screen-off controls. Manual IANA-style timezone overrides remain available. | Home Assistant |
 
 ### Night Schedule
 

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -81,7 +81,7 @@ The browser Device tab contains clock settings, day/night source, active screen 
 | Setting | Description |
 |---------|-------------|
 | **Clock Format** | Display the clock screen saver in 24-hour or 12-hour format. The 12-hour format omits AM/PM so the large clock still fits and can drift for burn-in prevention. Defaults to 24-hour. |
-| **Timezone** | IANA-style timezone for the clock and scheduled screen-off controls. The browser shows the current GMT offset. Defaults to UTC. |
+| **Timezone** | Defaults to Home Assistant's timezone for the clock and scheduled screen-off controls. You can still choose a manual IANA-style timezone override; the browser shows the current GMT offset for manual options. |
 
 ## Day/Night
 

--- a/docs/features/webserver.md
+++ b/docs/features/webserver.md
@@ -31,7 +31,7 @@ Use this tab for the main setup and day-to-day display behaviour:
 
 Use this tab for device-wide options and maintenance:
 
-- **Clock** — choose the on-screen clock format and timezone used by schedules.
+- **Clock** — choose the on-screen clock format and use Home Assistant's timezone, with a manual timezone override if needed.
 - **Day/Night** — optionally provide a Home Assistant entity to control day and night mode.
 - **Screen Brightness** — set active daytime and night-time brightness.
 - **Screen Tone** — adjust warm tinting for album art on ESP32-P4 devices.

--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -72,8 +72,8 @@
     screen_warmth_night: 60,
     clock_time_format: "24 Hour",
     clock_time_format_options: ["24 Hour", "12 Hour"],
-    clock_timezone: "UTC (GMT+0)",
-    clock_timezone_options: ["UTC (GMT+0)"],
+    clock_timezone: "Home Assistant (automatic)",
+    clock_timezone_options: ["Home Assistant (automatic)"],
     screen_rotation: "0",
     screen_rotation_options: ["0", "90", "180", "270"],
     auto_update: true,
@@ -1133,6 +1133,7 @@
   }
 
   function formatTimezoneOption(option) {
+    if (option === "Home Assistant (automatic)") return option;
     var tzId = timezoneId(option);
     var offset = timezoneOffsetMinutes(tzId, new Date());
     if (offset == null || !isFinite(offset)) return option;

--- a/docs/webserver/src/app.template.js
+++ b/docs/webserver/src/app.template.js
@@ -72,8 +72,8 @@
     screen_warmth_night: 60,
     clock_time_format: "24 Hour",
     clock_time_format_options: ["24 Hour", "12 Hour"],
-    clock_timezone: "UTC (GMT+0)",
-    clock_timezone_options: ["UTC (GMT+0)"],
+    clock_timezone: "Home Assistant (automatic)",
+    clock_timezone_options: ["Home Assistant (automatic)"],
     screen_rotation: "0",
     screen_rotation_options: ["0", "90", "180", "270"],
     auto_update: true,
@@ -1133,6 +1133,7 @@
   }
 
   function formatTimezoneOption(option) {
+    if (option === "Home Assistant (automatic)") return option;
     var tzId = timezoneId(option);
     var offset = timezoneOffsetMinutes(tzId, new Date());
     if (offset == null || !isFinite(offset)) return option;


### PR DESCRIPTION
## Summary
- Let ESPHome's Home Assistant time source receive the Home Assistant timezone by removing the explicit UTC override.
- Add a `Home Assistant (automatic)` timezone option as the default while keeping manual timezone overrides available.
- Update the browser settings defaults, generated webserver bundle, and docs to describe the new behavior.

ESPHome documents that omitting an explicit timezone lets the Home Assistant time platform update the runtime timezone from Home Assistant when time syncs: https://esphome.io/components/time/homeassistant/

## Verification
- `npm run check:all`
- Full compile: `builds/guition-esp32-s3-4848s040.factory.yaml`
- Full compile: `builds/guition-esp32-p4-jc1060p470.factory.yaml`
- Config validation: `builds/guition-esp32-p4-jc4880p443.factory.yaml`
- Config validation: `builds/guition-esp32-p4-jc8012p4a1.factory.yaml`
- Config validation: `builds/esp32-p4-86-panel.factory.yaml`
- Config validation: `builds/guition-esp32-p4-jc4880p443-90.yaml`

## Notes
- Existing devices that already restored a manual timezone selection will keep that setting until changed to `Home Assistant (automatic)`.
