### PR TITLE
Fix S3 artwork scanlines, reboots, and memory pressure

### DIFF
--- a/components/artwork_image/artwork_image.cpp
+++ b/components/artwork_image/artwork_image.cpp
@@ -18,8 +18,11 @@
 
 static const char *const TAG = "artwork_image";
 static const char *const CONTENT_TYPE_HEADER_NAME = "content-type";
-static constexpr uint32_t RETIRED_BUFFER_GRACE_MS = 1000;
-static constexpr size_t MAX_RETIRED_BUFFERS = 2;
+// A retired buffer only needs to outlive any in-flight LVGL render pass that
+// may still reference it; holding more buffers for longer doubles peak PSRAM
+// use during rapid album changes.
+static constexpr uint32_t RETIRED_BUFFER_GRACE_MS = 300;
+static constexpr size_t MAX_RETIRED_BUFFERS = 1;
 static constexpr size_t MAX_DOWNLOAD_BUFFER_SIZE = 2 * 1024 * 1024;
 static constexpr int LOCAL_ARTWORK_HTTP_TIMEOUT_MS = 6500;
 
@@ -58,10 +61,17 @@ class LocalHttpContainer : public http_request::HttpContainer {
   }
 
   bool is_read_complete() const override {
-    if (HttpContainer::is_read_complete()) {
+    if (this->client_ == nullptr) {
       return true;
     }
-    return this->is_chunked_ && esp_http_client_is_complete_data_received(this->client_);
+    // The base class treats content_length == 0 as "all bytes read", which
+    // wrongly reports completion immediately for connection-close-delimited
+    // responses (no Content-Length, not chunked). Only trust the byte count
+    // when a real Content-Length was provided; otherwise ask the client.
+    if (!this->is_chunked_ && this->content_length > 0) {
+      return this->bytes_read_ >= this->content_length;
+    }
+    return esp_http_client_is_complete_data_received(this->client_);
   }
 
   void end() override {
@@ -524,6 +534,19 @@ void ArtworkImage::loop() {
     this->finish_download_();
     return;
   }
+  // An incremental decoder (JPEG) spreads scanline output across loop()
+  // passes once the full file is buffered; keep pumping it without touching
+  // the downloader.
+  if (this->decoder_->is_decoding()) {
+    if (!this->decode_buffered_data_()) {
+      this->fail_download_();
+      return;
+    }
+    if (this->decoder_->is_finished()) {
+      this->finish_download_();
+    }
+    return;
+  }
   if (this->downloader_ == nullptr) {
     ESP_LOGE(TAG, "Downloader not instantiated; cannot download");
     return;
@@ -566,6 +589,12 @@ void ArtworkImage::loop() {
     }
     if (this->decoder_->is_finished()) {
       this->finish_download_();
+      return;
+    }
+    if (this->decoder_->is_decoding()) {
+      // Chunked downloads only learn their total size at this edge, so the
+      // incremental decoder may have just produced its first scanlines.
+      // Keep pumping it on subsequent loop() passes instead of failing.
       return;
     }
     ESP_LOGE(TAG, "HTTP transfer finished before image decoder completed");
@@ -1019,6 +1048,10 @@ void ArtworkImage::end_connection_() {
   this->decoder_.reset();
   this->discard_decode_buffer_();
   this->download_buffer_.reset();
+  // The JPEG decoder grows the download buffer to the full file size; give it
+  // back between downloads so each artwork instance doesn't pin its largest
+  // download in PSRAM indefinitely.
+  this->download_buffer_.shrink_to(this->download_buffer_initial_size_);
 }
 
 bool ArtworkImage::validate_url_(const std::string &url) {

--- a/components/artwork_image/artwork_image.h
+++ b/components/artwork_image/artwork_image.h
@@ -56,6 +56,11 @@ class ArtworkImage : public PollingComponent,
               image::Transparency transparency, uint32_t buffer_size, bool is_big_endian,
               bool allow_insecure_local_urls);
 
+  // The decoder may hold a pointer into download_buffer_ (libjpeg mem source),
+  // and members destruct in reverse declaration order — which would free the
+  // buffer first. Tear the decoder down explicitly while the buffer is alive.
+  ~ArtworkImage() { this->decoder_.reset(); }
+
   void draw(int x, int y, display::Display *display, Color color_on, Color color_off) override;
 
   void update() override;

--- a/components/artwork_image/image_decoder.cpp
+++ b/components/artwork_image/image_decoder.cpp
@@ -112,7 +112,9 @@ size_t DownloadBuffer::read(size_t len) {
     len = this->unread_;
   }
   this->unread_ -= len;
-  if (this->unread_ > 0) {
+  // len == 0 is the incremental-decode idle case; skip the self-memmove,
+  // which would otherwise copy the whole buffer through PSRAM every pass.
+  if (len > 0 && this->unread_ > 0) {
     memmove(this->data(), this->data(len), this->unread_);
   }
   return this->unread_;
@@ -140,6 +142,24 @@ size_t DownloadBuffer::resize(size_t size) {
     this->reset();
     return 0;
   }
+}
+
+size_t DownloadBuffer::shrink_to(size_t size) {
+  if (size == 0 || this->size_ <= size || this->unread_ > size) {
+    return this->size_;
+  }
+  uint8_t *new_buffer = this->allocator_.allocate(size);
+  if (new_buffer == nullptr) {
+    // Keep the existing (larger) buffer rather than losing data.
+    return this->size_;
+  }
+  if (this->unread_ > 0) {
+    memcpy(new_buffer, this->buffer_, this->unread_);
+  }
+  this->allocator_.deallocate(this->buffer_, this->size_);
+  this->buffer_ = new_buffer;
+  this->size_ = size;
+  return size;
 }
 
 }  // namespace artwork_image

--- a/components/artwork_image/image_decoder.h
+++ b/components/artwork_image/image_decoder.h
@@ -90,6 +90,13 @@ class ImageDecoder {
   bool is_finished() const { return this->download_size_ > 0 && this->decoded_bytes_ >= this->download_size_; }
   bool has_unknown_download_size() const { return this->download_size_ == 0; }
   void set_download_size(size_t download_size) { this->download_size_ = download_size; }
+  /**
+   * @brief Whether the decoder has started producing output and needs more
+   * decode() calls to finish, independent of further download data.
+   * Incremental decoders (JPEG) return true while scanline output is being
+   * spread across loop() passes.
+   */
+  virtual bool is_decoding() const { return false; }
 
  protected:
   ArtworkImage *image_;
@@ -127,6 +134,13 @@ class DownloadBuffer {
   void reset() { this->unread_ = 0; }
 
   size_t resize(size_t size);
+
+  /**
+   * Shrink the buffer back down to the given capacity, keeping any unread
+   * bytes. No-op if the buffer is already at or below the target size, if the
+   * unread data would not fit, or if the reallocation fails.
+   */
+  size_t shrink_to(size_t size);
 
  protected:
   RAMAllocator<uint8_t> allocator_{};

--- a/components/artwork_image/jpeg_image.cpp
+++ b/components/artwork_image/jpeg_image.cpp
@@ -3,22 +3,19 @@
 
 #include "esphome/components/display/display_buffer.h"
 #include "esphome/core/application.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esp_heap_caps.h"
+
+#include <cstdlib>
+#include <cstring>
 
 #include "artwork_image.h"
 static const char *const TAG = "artwork_image.jpeg";
 
 namespace esphome {
 namespace artwork_image {
-
-/// Custom error manager that longjmps instead of calling exit()
-struct JpegErrorMgr {
-  jpeg_error_mgr pub;
-  jmp_buf setjmp_buffer;
-  char message[JMSG_LENGTH_MAX];
-};
 
 static void jpeg_error_exit(j_common_ptr cinfo) {
   auto *err = reinterpret_cast<JpegErrorMgr *>(cinfo->err);
@@ -27,6 +24,14 @@ static void jpeg_error_exit(j_common_ptr cinfo) {
 }
 
 static constexpr size_t MAX_JPEG_DOWNLOAD_SIZE = 2 * 1024 * 1024;  // 2 MB
+// Per-loop() decode budget. Small enough to keep the UI responsive and to
+// leave PSRAM bandwidth for the RGB panel scan-out between passes, large
+// enough that a 480x480 image completes within a couple of seconds.
+static constexpr uint32_t JPEG_DECODE_BUDGET_MS = 12;
+// Scanlines decoded between budget checks.
+static constexpr int JPEG_SCANLINE_BATCH = 8;
+
+JpegDecoder::~JpegDecoder() { this->cleanup_(); }
 
 int JpegDecoder::prepare(size_t download_size) {
   if (download_size > MAX_JPEG_DOWNLOAD_SIZE) {
@@ -52,43 +57,53 @@ int HOT JpegDecoder::decode(uint8_t *buffer, size_t size) {
     ESP_LOGV(TAG, "Download not complete. Size: %zu/%zu", size, this->download_size_);
     return 0;
   }
+  if (!this->decode_started_) {
+    int ret = this->start_decode_(buffer, size);
+    if (ret < 0) {
+      return ret;
+    }
+  }
+  return this->decode_scanlines_();
+}
+
+int JpegDecoder::start_decode_(uint8_t *buffer, size_t size) {
   ESP_LOGD(TAG, "JPEG decode start: %zu bytes", size);
 
-  jpeg_decompress_struct cinfo;
-  JpegErrorMgr jerr{};
+  std::memset(&this->cinfo_, 0, sizeof(this->cinfo_));
+  std::memset(&this->jerr_, 0, sizeof(this->jerr_));
+  this->cinfo_.err = jpeg_std_error(&this->jerr_.pub);
+  this->jerr_.pub.error_exit = jpeg_error_exit;
 
-  cinfo.err = jpeg_std_error(&jerr.pub);
-  jerr.pub.error_exit = jpeg_error_exit;
-
-  // Raw pointer for longjmp safety — unique_ptr destructors are skipped by longjmp
-  uint8_t *row_buffer = nullptr;
-
-  if (setjmp(jerr.setjmp_buffer)) {
-    ESP_LOGE(TAG, "JPEG decode error: %s", jerr.message);
-    free(row_buffer);
-    jpeg_destroy_decompress(&cinfo);
+  if (setjmp(this->jerr_.setjmp_buffer)) {
+    ESP_LOGE(TAG, "JPEG decode error: %s", this->jerr_.message);
+    this->cleanup_();
     return DECODE_ERROR_UNSUPPORTED_FORMAT;
   }
 
-  jpeg_create_decompress(&cinfo);
-  jpeg_mem_src(&cinfo, buffer, size);
+  jpeg_create_decompress(&this->cinfo_);
+  this->cinfo_created_ = true;
+  // NOTE: libjpeg keeps this pointer until decode finishes. The download
+  // buffer must not move, grow, shrink, or be compacted while a decode is
+  // in progress. ArtworkImage guarantees this: decode only starts once the
+  // full file is buffered, DownloadBuffer::read(0) leaves the data in place,
+  // and end_connection_() destroys the decoder before touching the buffer.
+  jpeg_mem_src(&this->cinfo_, buffer, size);
 
-  if (jpeg_read_header(&cinfo, TRUE) != JPEG_HEADER_OK) {
+  if (jpeg_read_header(&this->cinfo_, TRUE) != JPEG_HEADER_OK) {
     ESP_LOGE(TAG, "Could not read JPEG header");
-    jpeg_destroy_decompress(&cinfo);
+    this->cleanup_();
     return DECODE_ERROR_INVALID_TYPE;
   }
 
-  int src_w = cinfo.image_width;
-  int src_h = cinfo.image_height;
-  ESP_LOGD(TAG, "JPEG header: %dx%d, components=%d, progressive=%s",
-           src_w, src_h, cinfo.num_components,
-           cinfo.progressive_mode ? "yes" : "no");
-  // Request RGB output regardless of input colorspace
-  cinfo.out_color_space = JCS_RGB;
+  int src_w = this->cinfo_.image_width;
+  int src_h = this->cinfo_.image_height;
+  ESP_LOGD(TAG, "JPEG header: %dx%d, components=%d, progressive=%s", src_w, src_h, this->cinfo_.num_components,
+           this->cinfo_.progressive_mode ? "yes" : "no");
+  // Request RGB output regardless of input colorspace.
+  this->cinfo_.out_color_space = JCS_RGB;
   // Use fast integer IDCT — slightly lower quality but faster on ESP32
   // and avoids pulling in the float IDCT code path.
-  cinfo.dct_method = JDCT_IFAST;
+  this->cinfo_.dct_method = JDCT_IFAST;
 
   // Use IDCT scaling to downscale during decode
   int target_w = this->image_->get_fixed_width();
@@ -101,96 +116,139 @@ int HOT JpegDecoder::decode(uint8_t *buffer, size_t size) {
     int min_h = target_h;
     constexpr unsigned int denoms[] = {8, 4, 2, 1};
     for (unsigned int denom : denoms) {
-      cinfo.scale_num = 1;
-      cinfo.scale_denom = denom;
-      jpeg_calc_output_dimensions(&cinfo);
-      if (static_cast<int>(cinfo.output_width) >= min_w &&
-          static_cast<int>(cinfo.output_height) >= min_h) {
+      this->cinfo_.scale_num = 1;
+      this->cinfo_.scale_denom = denom;
+      jpeg_calc_output_dimensions(&this->cinfo_);
+      if (static_cast<int>(this->cinfo_.output_width) >= min_w &&
+          static_cast<int>(this->cinfo_.output_height) >= min_h) {
         break;
       }
     }
-    if (static_cast<int>(cinfo.output_width) < min_w ||
-        static_cast<int>(cinfo.output_height) < min_h) {
-      cinfo.scale_num = 1;
-      cinfo.scale_denom = 1;
-      jpeg_calc_output_dimensions(&cinfo);
+    if (static_cast<int>(this->cinfo_.output_width) < min_w ||
+        static_cast<int>(this->cinfo_.output_height) < min_h) {
+      this->cinfo_.scale_num = 1;
+      this->cinfo_.scale_denom = 1;
+      jpeg_calc_output_dimensions(&this->cinfo_);
     }
   } else {
-    jpeg_calc_output_dimensions(&cinfo);
+    jpeg_calc_output_dimensions(&this->cinfo_);
   }
 
-  int out_w = cinfo.output_width;
-  int out_h = cinfo.output_height;
-  if (out_w != src_w || out_h != src_h) {
-    ESP_LOGD(TAG, "Using IDCT downscale: %dx%d -> %dx%d", src_w, src_h, out_w, out_h);
+  this->out_w_ = this->cinfo_.output_width;
+  this->out_h_ = this->cinfo_.output_height;
+  if (this->out_w_ != src_w || this->out_h_ != src_h) {
+    ESP_LOGD(TAG, "Using IDCT downscale: %dx%d -> %dx%d", src_w, src_h, this->out_w_, this->out_h_);
   }
 
-  if (!this->set_size(out_w, out_h)) {
-    jpeg_destroy_decompress(&cinfo);
+  if (!this->set_size(this->out_w_, this->out_h_)) {
+    this->cleanup_();
     return DECODE_ERROR_OUT_OF_MEMORY;
   }
 
-  jpeg_start_decompress(&cinfo);
+  jpeg_start_decompress(&this->cinfo_);
 
-  // Allocate row buffers (raw pointers — safe across longjmp)
-  size_t row_stride = static_cast<size_t>(out_w) * 3;
-  row_buffer = static_cast<uint8_t *>(heap_caps_malloc(row_stride, MALLOC_CAP_8BIT));
-  if (row_buffer == nullptr) {
+  size_t row_stride = static_cast<size_t>(this->out_w_) * 3;
+  this->row_buffer_ = static_cast<uint8_t *>(heap_caps_malloc(row_stride, MALLOC_CAP_8BIT));
+  if (this->row_buffer_ == nullptr) {
     ESP_LOGE(TAG, "JPEG row buffer allocation failed: %zu bytes", row_stride);
-    jpeg_destroy_decompress(&cinfo);
+    this->cleanup_();
     return DECODE_ERROR_OUT_OF_MEMORY;
   }
 
-  bool use_rgb565 = (this->image_->image_type() == image::ImageType::IMAGE_TYPE_RGB565);
-  bool big_endian = this->image_->is_big_endian();
+  this->use_rgb565_ = (this->image_->image_type() == image::ImageType::IMAGE_TYPE_RGB565);
+  this->big_endian_ = this->image_->is_big_endian();
+  this->source_size_ = size;
+  this->y_ = 0;
+  this->decode_started_ = true;
+  return 0;
+}
 
-  int y = 0;
-  while (cinfo.output_scanline < cinfo.output_height) {
-    uint8_t *row_ptr = row_buffer;
-    jpeg_read_scanlines(&cinfo, &row_ptr, 1);
-
-    if ((y & 63) == 0) {
-      App.feed_wdt();
-    }
-
-    if (use_rgb565) {
-      // Convert RGB888 -> RGB565 in-place (2 bpp fits within the 3 bpp
-      // source buffer, so no separate allocation needed).  We read forward
-      // and write forward; the write pointer never overtakes the read
-      // pointer because 2 < 3.
-      uint8_t *dst = row_buffer;
-      for (int x = 0; x < out_w; x++) {
-        uint8_t r = row_buffer[x * 3 + 0];
-        uint8_t g = row_buffer[x * 3 + 1];
-        uint8_t b = row_buffer[x * 3 + 2];
-        uint16_t rgb565 = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
-        if (big_endian) {
-          dst[0] = rgb565 >> 8;
-          dst[1] = rgb565 & 0xFF;
-        } else {
-          dst[0] = rgb565 & 0xFF;
-          dst[1] = rgb565 >> 8;
-        }
-        dst += 2;
-      }
-      this->draw_rgb565_block(0, y, out_w, 1, row_buffer);
-    } else {
-      // Per-pixel draw for other image types
-      for (int x = 0; x < out_w; x++) {
-        Color color(row_buffer[x * 3 + 0], row_buffer[x * 3 + 1], row_buffer[x * 3 + 2]);
-        this->draw(x, y, 1, 1, color);
-      }
-    }
-    y++;
+int JpegDecoder::decode_scanlines_() {
+  // Re-arm the longjmp target: the one from start_decode_() pointed into a
+  // stack frame that no longer exists.
+  if (setjmp(this->jerr_.setjmp_buffer)) {
+    ESP_LOGE(TAG, "JPEG decode error: %s", this->jerr_.message);
+    this->cleanup_();
+    return DECODE_ERROR_UNSUPPORTED_FORMAT;
   }
 
-  jpeg_finish_decompress(&cinfo);
-  jpeg_destroy_decompress(&cinfo);
-  free(row_buffer);
+  const uint32_t start = millis();
+  while (this->cinfo_.output_scanline < this->cinfo_.output_height) {
+    for (int i = 0; i < JPEG_SCANLINE_BATCH && this->cinfo_.output_scanline < this->cinfo_.output_height; i++) {
+      uint8_t *row_ptr = this->row_buffer_;
+      jpeg_read_scanlines(&this->cinfo_, &row_ptr, 1);
 
-  this->decoded_bytes_ = size;
-  ESP_LOGD(TAG, "JPEG decode finished: output=%dx%d", out_w, out_h);
-  return size;
+      if (this->use_rgb565_) {
+        // Convert RGB888 -> RGB565 in-place (2 bpp fits within the 3 bpp
+        // source buffer, so no separate allocation needed). We read forward
+        // and write forward; the write pointer never overtakes the read
+        // pointer because 2 < 3.
+        uint8_t *dst = this->row_buffer_;
+        for (int x = 0; x < this->out_w_; x++) {
+          uint8_t r = this->row_buffer_[x * 3 + 0];
+          uint8_t g = this->row_buffer_[x * 3 + 1];
+          uint8_t b = this->row_buffer_[x * 3 + 2];
+          uint16_t rgb565 = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
+          if (this->big_endian_) {
+            dst[0] = rgb565 >> 8;
+            dst[1] = rgb565 & 0xFF;
+          } else {
+            dst[0] = rgb565 & 0xFF;
+            dst[1] = rgb565 >> 8;
+          }
+          dst += 2;
+        }
+        this->draw_rgb565_block(0, this->y_, this->out_w_, 1, this->row_buffer_);
+      } else {
+        // Per-pixel draw for other image types
+        for (int x = 0; x < this->out_w_; x++) {
+          Color color(this->row_buffer_[x * 3 + 0], this->row_buffer_[x * 3 + 1], this->row_buffer_[x * 3 + 2]);
+          this->draw(x, this->y_, 1, 1, color);
+        }
+      }
+      this->y_++;
+    }
+    App.feed_wdt();
+    if (millis() - start >= JPEG_DECODE_BUDGET_MS) {
+      break;
+    }
+  }
+
+  if (this->cinfo_.output_scanline < this->cinfo_.output_height) {
+    // Budget exhausted; resume on the next loop() pass.
+    return 0;
+  }
+
+  jpeg_finish_decompress(&this->cinfo_);
+  ESP_LOGD(TAG, "JPEG decode finished: output=%dx%d", this->out_w_, this->out_h_);
+  size_t decoded = this->source_size_;
+  this->decoded_bytes_ = decoded;
+  this->cleanup_();
+  return static_cast<int>(decoded);
+}
+
+void JpegDecoder::cleanup_() {
+  if (this->row_buffer_ != nullptr) {
+    free(this->row_buffer_);
+    this->row_buffer_ = nullptr;
+  }
+  if (this->cinfo_created_) {
+    // Re-arm the longjmp target: cleanup_() can run from the destructor or an
+    // error path where the previously armed jmp_buf belongs to a dead frame.
+    // If destroy itself errors we skip it (leaking the pool) rather than jump
+    // into invalid stack.
+    if (setjmp(this->jerr_.setjmp_buffer) == 0) {
+      jpeg_destroy_decompress(&this->cinfo_);
+    }
+    this->cinfo_created_ = false;
+  }
+  this->decode_started_ = false;
+  this->source_size_ = 0;
+  this->out_w_ = 0;
+  this->out_h_ = 0;
+  this->y_ = 0;
+  this->use_rgb565_ = false;
+  this->big_endian_ = false;
 }
 
 }  // namespace artwork_image

--- a/components/artwork_image/jpeg_image.h
+++ b/components/artwork_image/jpeg_image.h
@@ -5,25 +5,61 @@
 #ifdef USE_ARTWORK_IMAGE_JPEG_SUPPORT
 #include <jpeglib.h>
 #include <csetjmp>
+#include <cstddef>
+#include <cstdint>
 
 namespace esphome {
 namespace artwork_image {
 
+/// Custom error manager that longjmps instead of calling exit().
+/// The jmp_buf is re-armed by setjmp() at the top of every method that calls
+/// into libjpeg: decode state persists across loop() passes, and a longjmp
+/// into a dead stack frame is undefined behavior.
+struct JpegErrorMgr {
+  jpeg_error_mgr pub;
+  jmp_buf setjmp_buffer;
+  char message[JMSG_LENGTH_MAX];
+};
+
 /**
  * @brief Image decoder specialization for JPEG images.
+ *
+ * The full JPEG must be buffered before decoding starts (libjpeg's mem source
+ * needs the whole file), but the scanline output work is spread across
+ * multiple loop() passes on a time budget. This keeps the main loop
+ * responsive and, more importantly, avoids a single long burst of PSRAM
+ * writes that competes with the RGB panel's DMA scan-out.
  */
 class JpegDecoder : public ImageDecoder {
  public:
   /**
    * @brief Construct a new JPEG Decoder object.
    *
-   * @param display The image to decode the stream into.
+   * @param image The image to decode the stream into.
    */
   JpegDecoder(ArtworkImage *image) : ImageDecoder(image) {}
-  ~JpegDecoder() override {}
+  ~JpegDecoder() override;
 
   int prepare(size_t download_size) override;
   int HOT decode(uint8_t *buffer, size_t size) override;
+  bool is_decoding() const override { return this->decode_started_ && !this->is_finished(); }
+
+ protected:
+  int start_decode_(uint8_t *buffer, size_t size);
+  int decode_scanlines_();
+  void cleanup_();
+
+  jpeg_decompress_struct cinfo_{};
+  JpegErrorMgr jerr_{};
+  uint8_t *row_buffer_{nullptr};
+  size_t source_size_{0};
+  int out_w_{0};
+  int out_h_{0};
+  int y_{0};
+  bool cinfo_created_{false};
+  bool decode_started_{false};
+  bool use_rgb565_{false};
+  bool big_endian_{false};
 };
 
 }  // namespace artwork_image

--- a/components/mipi_rgb/mipi_rgb.cpp
+++ b/components/mipi_rgb/mipi_rgb.cpp
@@ -132,8 +132,6 @@ void MipiRgb::setup() {
 void MipiRgb::common_setup_() {
   esp_lcd_rgb_panel_config_t config{};
   config.flags.fb_in_psram = 1;
-  // Album-art redraws are full-screen and PSRAM-heavy. A larger internal bounce
-  // buffer gives the RGB DMA more headroom while JPEG decode/LVGL compete for PSRAM.
   config.bounce_buffer_size_px = this->width_ * RGB_BOUNCE_BUFFER_ROWS;
   config.num_fbs = 1;
   config.timings.h_res = this->width_;
@@ -248,8 +246,30 @@ void MipiRgb::write_to_display_(int x_start, int y_start, int w, int h, const ui
       ptr += stride;  // next line
     }
   }
-  if (err != ESP_OK)
+  if (err != ESP_OK) {
     ESP_LOGE(TAG, "lcd_lcd_panel_draw_bitmap failed: %s", esp_err_to_name(err));
+    return;
+  }
+  // Heavy PSRAM traffic during large blits (album-art redraws) can underflow
+  // the bounce buffer and leave the scan-out phase shifted, which shows as
+  // persistent horizontal banding. After a redraw cycle that rewrote at least
+  // half the panel finishes at the bottom edge, request a one-shot restart to
+  // re-sync the phase (executed at VSYNC via CONFIG_LCD_RGB_RESTART_IN_VSYNC).
+  // Rate-limited so full-screen fade animations don't restart every frame.
+  this->refresh_pixels_ += static_cast<size_t>(w) * static_cast<size_t>(h);
+  if (y_start + h >= static_cast<int>(this->height_)) {
+    if (this->refresh_pixels_ >= this->width_ * this->height_ / 2) {
+      const uint32_t now = millis();
+      if (now - this->last_restart_ms_ >= 500) {
+        this->last_restart_ms_ = now;
+        esp_err_t restart_err = esp_lcd_rgb_panel_restart(this->handle_);
+        if (restart_err != ESP_OK) {
+          ESP_LOGV(TAG, "rgb panel restart skipped: %s", esp_err_to_name(restart_err));
+        }
+      }
+    }
+    this->refresh_pixels_ = 0;
+  }
 }
 
 bool MipiRgb::check_buffer_() {

--- a/components/mipi_rgb/mipi_rgb.h
+++ b/components/mipi_rgb/mipi_rgb.h
@@ -93,6 +93,10 @@ class MipiRgb : public display::Display {
   uint16_t y_low_{1};
   uint16_t x_high_{0};
   uint16_t y_high_{0};
+  // Pixels written since the last scan-phase resync decision; used to detect
+  // large (artwork-sized) redraws that can shift the RGB scan-out phase.
+  size_t refresh_pixels_{0};
+  uint32_t last_restart_ms_{0};
 
   esp_lcd_panel_handle_t handle_{};
 };

--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -31,6 +31,15 @@ esp32:
       # The S3 RGB panel scans from PSRAM while LVGL and artwork decoding also
       # use PSRAM. Recover the LCD DMA at VSYNC if that stream stalls.
       CONFIG_LCD_RGB_RESTART_IN_VSYNC: "y"
+      # Keep the RGB bounce-buffer refill ISR alive while flash writes
+      # (NVS/preferences saves) briefly disable the flash cache. Without these
+      # the scan-out underflows during any flash write and the panel can show
+      # persistent shifted horizontal bands until the next restart.
+      # SPIRAM_FETCH_INSTRUCTIONS/RODATA move code/rodata out of flash so the
+      # cache can keep serving the ISR during those windows.
+      CONFIG_LCD_RGB_ISR_IRAM_SAFE: "y"
+      CONFIG_SPIRAM_FETCH_INSTRUCTIONS: "y"
+      CONFIG_SPIRAM_RODATA: "y"
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Hi! After getting distracted by other stuff for a couple of months, I'm back playing with my ESP32-S3s. Running the latest, I was seeing some scanlines and (occasional) crashes when changing artwork. I had Fable bucks to burn and a few hours, which resulted in this. I've been testing for the past day or so, and it has been rock solid. As always, thanks for the project, it's awesome.

Commit message:

Display stability (Guition ESP32-S3 4848S040):
- Keep the RGB bounce-buffer refill ISR alive during flash writes (CONFIG_LCD_RGB_ISR_IRAM_SAFE + SPIRAM_FETCH_INSTRUCTIONS/RODATA) so NVS/preferences saves no longer underflow the panel scan-out.
- Request a one-shot, VSYNC-aligned RGB panel restart after redraws that rewrite at least half the panel, so a shifted scan phase self-heals after album-art blits instead of persisting as horizontal bands.

Incremental JPEG decode:
- Spread scanline output across loop() passes on a 12 ms budget instead of blocking the main loop for 1-2 seconds per album change, removing the long PSRAM write burst that competed with the RGB DMA scan-out. Decode state lives on the decoder; setjmp is re-armed on every libjpeg entry, including teardown, and ~ArtworkImage destroys the decoder before the download buffer it points into.
- Skip DownloadBuffer's full-buffer self-memmove when the decoder consumes zero bytes during pumping.

Memory:
- Shrink the artwork download buffer back to its initial size after each download instead of pinning the largest-JPEG high-water mark forever (per artwork instance).
- Tighten the retired artwork buffer policy (1 buffer, 300 ms grace) to halve peak PSRAM use during rapid album changes.

Also fix local HTTP downloads reporting completion immediately for connection-close-delimited responses without a Content-Length.