### PR TITLE
Default firmware auto updates off

### DIFF
--- a/common/addon/firmware_update.yaml
+++ b/common/addon/firmware_update.yaml
@@ -68,7 +68,11 @@ switch:
     internal: ${ha_config_internal}
     icon: "mdi:update"
     optimistic: true
-    restore_mode: RESTORE_DEFAULT_ON
+    restore_mode: RESTORE_DEFAULT_OFF
+    on_turn_on:
+      - lambda: 'global_preferences->sync();'
+    on_turn_off:
+      - lambda: 'global_preferences->sync();'
 
 select:
   - platform: template

--- a/common/device/base.yaml
+++ b/common/device/base.yaml
@@ -28,6 +28,10 @@ preferences:
   # is running; explicit sync calls still save critical setup changes.
   flash_write_interval: never
 
+esphome:
+  includes:
+    - ../../common/addon/speaker_group_helpers.h
+
 safe_mode:
   # Safe mode marks a boot successful after 60s, which also writes to flash.
   # On display-heavy builds this can collide with active LVGL/PSRAM traffic.


### PR DESCRIPTION
I was running with a dev build for dev testing purposes, but that meant that every 24 hours the screen would start flashing and then it would reboot back into the firmware's default mode, the 'WiFi provisioning' screen. The thinking sand said this is the fix, and I've been testing for a few days now without it recurring, so I think it's right. 😅 

Auto-updating should be an explicit opt-in so devices do not unexpectedly replace locally configured firmware with a published build. Sync switch changes immediately so the user's choice survives reboots even when flash writes are otherwise deferred.

Also fix the shared helper include path used by local dev builds.