### PR TITLE
Prevent shifted progress-bar artifacts on Guition ESP32-S3

### DIFF
--- a/devices/guition-esp32-s3-4848s040/device/device.yaml
+++ b/devices/guition-esp32-s3-4848s040/device/device.yaml
@@ -28,9 +28,6 @@ esp32:
   framework:
     type: esp-idf
     sdkconfig_options:
-      # The S3 RGB panel scans from PSRAM while LVGL and artwork decoding also
-      # use PSRAM. Recover the LCD DMA at VSYNC if that stream stalls.
-      CONFIG_LCD_RGB_RESTART_IN_VSYNC: "y"
       # Keep the RGB bounce-buffer refill ISR alive while flash writes
       # (NVS/preferences saves) briefly disable the flash cache. Without these
       # the scan-out underflows during any flash write and the panel can show


### PR DESCRIPTION
## Summary

- remove the ESP-IDF automatic RGB-panel restart at VSYNC from the Guition ESP32-S3 4848S040 configuration
- keep the IRAM-safe RGB interrupt and PSRAM execution safeguards added by the earlier display-stability work

## Why

A user testing the recent display changes reported intermittent shifted pixels and image content around the progress bar. Their device remained stable for a full day after removing `CONFIG_LCD_RGB_RESTART_IN_VSYNC`, indicating that the automatic VSYNC restart was triggering the visible scan-position artifact.

Closes #142.

## Validation

- `git diff --check`
- Guition ESP32-S3 4848S040 factory firmware compiled successfully with ESPHome 2026.6.4, matching the release workflow
- Other device builds were not run because this configuration file is included only by the Guition ESP32-S3 4848S040 profile

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- This removes an internal display-driver setting to restore stable rendering; there is no user-facing option or workflow to document.
