### PR TITLE
Support ESPHome 2026.7 display transforms

### DIFF
--- a/components/mipi_rgb/display.py
+++ b/components/mipi_rgb/display.py
@@ -123,16 +123,19 @@ def data_pin_set(length):
 
 def model_schema(config):
     model = MODELS[config[CONF_MODEL].upper()]
-    transform = cv.Any(
-        cv.Schema(
-            {
-                cv.Required(CONF_MIRROR_X): cv.boolean,
-                cv.Required(CONF_MIRROR_Y): cv.boolean,
-                **model.swap_xy_schema(),
-            }
-        ),
-        cv.one_of(CONF_DISABLED, lower=True),
-    )
+    if hasattr(model, "transform_schema"):
+        transform = model.transform_schema()
+    else:
+        transform = cv.Any(
+            cv.Schema(
+                {
+                    cv.Required(CONF_MIRROR_X): cv.boolean,
+                    cv.Required(CONF_MIRROR_Y): cv.boolean,
+                    **model.swap_xy_schema(),
+                }
+            ),
+            cv.one_of(CONF_DISABLED, lower=True),
+        )
     # RPI model does not use an init sequence, indicates with empty list
     if model.initsequence is None:
         # Custom model requires an init sequence


### PR DESCRIPTION
## What changed

- Use the display driver's `transform_schema()` API introduced for ESPHome 2026.7.
- Keep the existing `swap_xy_schema` path as a compatibility fallback for ESPHome 2026.6.

## Why

ESPHome 2026.7 removed `swap_xy_schema` from the ST7701S driver. This caused the Guition ESP32-S3 4848S040 configuration to stop during validation with:

`AttributeError: 'ST7701S' object has no attribute 'swap_xy_schema'`

The compatibility check lets the external MIPI RGB component work with both the current pinned ESPHome release and ESPHome 2026.7 without changing device behaviour.

## Impact

- Restores ESPHome 2026.7 compatibility for the affected S3 display configuration.
- Preserves ESPHome 2026.6 compatibility.
- Does not change the display transform selected by existing device YAML.

## Verification

- Fully compiled the Guition ESP32-S3 4848S040 factory firmware with ESPHome 2026.7.0 after the fix.
- Fully compiled all four ESP32-P4 factory configurations with ESPHome 2026.7.0, then regenerated each one against the patched local component.
- Validated the affected S3 configuration with the project's pinned ESPHome 2026.6.4 release.
- Ran `npm run check:all` successfully.
- Physical hardware was not flashed as part of this check.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- This only updates internal build compatibility; device behaviour and user configuration remain unchanged.
