### PR TITLE
Fix speaker grouping for remote package users

### DIFF
--- a/common/addon/music.yaml
+++ b/common/addon/music.yaml
@@ -21,7 +21,7 @@ globals:
 
 external_components:
   - source: github://jtenniswood/esphome-media-player@main
-    components: [artwork_image, mipi_rgb]
+    components: [artwork_image, mipi_rgb, speaker_group_helpers]
     refresh: 1s
 
 http_request:

--- a/common/addon/speaker_group.yaml
+++ b/common/addon/speaker_group.yaml
@@ -10,6 +10,9 @@
 # Requires: homeassistant/speakers.yaml template sensor in HA.
 # =============================================================================
 
+speaker_group_helpers:
+  id: speaker_group_helpers_component
+
 globals:
   - id: speaker_count
     type: int
@@ -351,7 +354,7 @@ script:
       - lambda: |-
           std::string raw = id(group_members_sensor).has_state()
               ? id(group_members_sensor).state : "";
-          std::vector<std::string> members = esphome::speaker_group::parse_group_members(raw);
+          std::vector<std::string> members = id(speaker_group_helpers_component).parse_group_members(raw);
 
           std::string selected = id(media_player_entity).state;
           int count = id(speaker_count);

--- a/common/device/base.yaml
+++ b/common/device/base.yaml
@@ -28,10 +28,6 @@ preferences:
   # is running; explicit sync calls still save critical setup changes.
   flash_write_interval: never
 
-esphome:
-  includes:
-    - ../common/addon/speaker_group_helpers.h
-
 safe_mode:
   # Safe mode marks a boot successful after 60s, which also writes to flash.
   # On display-heavy builds this can collide with active LVGL/PSRAM traffic.

--- a/components/speaker_group_helpers/__init__.py
+++ b/components/speaker_group_helpers/__init__.py
@@ -1,0 +1,22 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+
+CODEOWNERS = ["@jtenniswood"]
+
+speaker_group_helpers_ns = cg.esphome_ns.namespace("speaker_group_helpers")
+SpeakerGroupHelpers = speaker_group_helpers_ns.class_(
+    "SpeakerGroupHelpers", cg.Component
+)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(SpeakerGroupHelpers),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)

--- a/components/speaker_group_helpers/speaker_group_helpers.h
+++ b/components/speaker_group_helpers/speaker_group_helpers.h
@@ -4,6 +4,11 @@
 #include <string>
 #include <vector>
 
+#if __has_include("esphome/core/component.h")
+#include "esphome/core/component.h"
+#define SPEAKER_GROUP_HELPERS_HAS_COMPONENT 1
+#endif
+
 namespace esphome {
 namespace speaker_group {
 
@@ -54,4 +59,17 @@ inline std::vector<std::string> parse_group_members(std::string raw) {
 }
 
 }  // namespace speaker_group
+
+namespace speaker_group_helpers {
+
+#ifdef SPEAKER_GROUP_HELPERS_HAS_COMPONENT
+class SpeakerGroupHelpers : public Component {
+ public:
+  std::vector<std::string> parse_group_members(std::string raw) const {
+    return speaker_group::parse_group_members(raw);
+  }
+};
+#endif
+
+}  // namespace speaker_group_helpers
 }  // namespace esphome

--- a/devices/esp32-p4-86-panel/dev.yaml
+++ b/devices/esp32-p4-86-panel/dev.yaml
@@ -13,4 +13,4 @@ external_components:
   - source:
       type: local
       path: ../../components
-    components: [artwork_image, mipi_rgb]
+    components: [artwork_image, mipi_rgb, speaker_group_helpers]

--- a/devices/guition-esp32-p4-jc1060p470/dev.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/dev.yaml
@@ -15,4 +15,4 @@ external_components:
   - source:
       type: local
       path: ../../components
-    components: [artwork_image, mipi_rgb]
+    components: [artwork_image, mipi_rgb, speaker_group_helpers]

--- a/devices/guition-esp32-p4-jc4880p443/dev.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/dev.yaml
@@ -15,4 +15,4 @@ external_components:
   - source:
       type: local
       path: ../../components
-    components: [artwork_image, mipi_rgb]
+    components: [artwork_image, mipi_rgb, speaker_group_helpers]

--- a/devices/guition-esp32-p4-jc8012p4a1/dev.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/dev.yaml
@@ -15,4 +15,4 @@ external_components:
   - source:
       type: local
       path: ../../components
-    components: [artwork_image, gsl3680, mipi_rgb]
+    components: [artwork_image, gsl3680, mipi_rgb, speaker_group_helpers]

--- a/devices/guition-esp32-s3-4848s040/dev.yaml
+++ b/devices/guition-esp32-s3-4848s040/dev.yaml
@@ -13,4 +13,4 @@ external_components:
   - source:
       type: local
       path: ../../components
-    components: [artwork_image, mipi_rgb]
+    components: [artwork_image, mipi_rgb, speaker_group_helpers]

--- a/docs/advanced/troubleshooting.md
+++ b/docs/advanced/troubleshooting.md
@@ -53,6 +53,12 @@ esphome compile /config/music-7inch.yaml
 
 If the folder name is different in your error, delete that folder instead. If you are unsure which folder is affected, deleting `/config/.esphome/external_components/` is also safe; ESPHome will download the external components again on the next compile.
 
+## Firmware compile fails with `speaker_group has not been declared`
+
+Older versions of the project loaded the speaker-group helper through a relative file path that ESPHome resolves incorrectly for remote packages. Update your package to the latest `main` version, choose **Clean Build Files** from the device menu, and compile again.
+
+If your configuration is pinned to an older commit, update or remove the pinned `ref`. As a temporary workaround, place [speaker_group_helpers.h](https://raw.githubusercontent.com/jtenniswood/esphome-media-player/main/components/speaker_group_helpers/speaker_group_helpers.h) at `/config/common/addon/speaker_group_helpers.h` on the Home Assistant host.
+
 ## The screen is black / not responding
 
 - Verify the device is powered via the USB-C port with an adequate power supply (5V 2A recommended).

--- a/docs/advanced/troubleshooting.md
+++ b/docs/advanced/troubleshooting.md
@@ -57,7 +57,7 @@ If the folder name is different in your error, delete that folder instead. If yo
 
 Older versions of the project loaded the speaker-group helper through a relative file path that ESPHome resolves incorrectly for remote packages. Update your package to the latest `main` version, choose **Clean Build Files** from the device menu, and compile again.
 
-If your configuration is pinned to an older commit, update or remove the pinned `ref`. As a temporary workaround, place [speaker_group_helpers.h](https://raw.githubusercontent.com/jtenniswood/esphome-media-player/main/components/speaker_group_helpers/speaker_group_helpers.h) at `/config/common/addon/speaker_group_helpers.h` on the Home Assistant host.
+If your configuration is pinned to an older commit, update or remove the pinned `ref`. The old helper path resolves differently depending on where your main YAML file is stored, so there is no single manual file location that works reliably for pinned remote packages.
 
 ## The screen is black / not responding
 

--- a/docs/development/speaker-grouping-parser-notes.md
+++ b/docs/development/speaker-grouping-parser-notes.md
@@ -50,7 +50,7 @@ The parser also tolerates Python-style list strings with brackets and quotes:
 Empty list strings and Home Assistant no-data states such as `None`, `unknown`,
 and `unavailable` are treated as no grouped members.
 
-`common/addon/speaker_group_helpers.h` owns this parsing so it can be checked
+`components/speaker_group_helpers/speaker_group_helpers.h` owns this parsing so it can be checked
 outside firmware builds. Run `npm run check:speaker-group` after changing
 accepted `group_members` formats.
 

--- a/docs/development/tech-debt-cleanup-backlog.md
+++ b/docs/development/tech-debt-cleanup-backlog.md
@@ -730,7 +730,7 @@ Progress updates:
 - Status: partially fixed. `docs/development/speaker-grouping-parser-notes.md`
   now documents the expected `sensor.speaker_group` attribute format, tolerated
   `group_members` strings, invariants, and manual regression scenarios.
-  `common/addon/speaker_group_helpers.h` now owns the `group_members` parser
+  `components/speaker_group_helpers/speaker_group_helpers.h` now owns the `group_members` parser
   used by the firmware lambda, and `scripts/check_speaker_group_helpers.py`
   covers common Home Assistant comma-separated and quoted-list formats on the
   host, plus empty list and no-data values such as `None`, `unknown`, and

--- a/product/devices.json
+++ b/product/devices.json
@@ -16,7 +16,8 @@
         "local_components": [
           "artwork_image",
           "gsl3680",
-          "mipi_rgb"
+          "mipi_rgb",
+          "speaker_group_helpers"
         ]
       },
       "esphome": {
@@ -78,7 +79,8 @@
         "display_rotation": "0",
         "local_components": [
           "artwork_image",
-          "mipi_rgb"
+          "mipi_rgb",
+          "speaker_group_helpers"
         ]
       },
       "esphome": {
@@ -137,7 +139,8 @@
         "display_rotation": "0",
         "local_components": [
           "artwork_image",
-          "mipi_rgb"
+          "mipi_rgb",
+          "speaker_group_helpers"
         ]
       },
       "esphome": {
@@ -195,7 +198,8 @@
         "friendly_name": "Music Dashboard Dev",
         "local_components": [
           "artwork_image",
-          "mipi_rgb"
+          "mipi_rgb",
+          "speaker_group_helpers"
         ]
       },
       "esphome": {
@@ -251,7 +255,8 @@
         "friendly_name": "Music Dashboard Dev",
         "local_components": [
           "artwork_image",
-          "mipi_rgb"
+          "mipi_rgb",
+          "speaker_group_helpers"
         ]
       },
       "esphome": {

--- a/scripts/check_speaker_group_helpers.py
+++ b/scripts/check_speaker_group_helpers.py
@@ -12,7 +12,7 @@ from tempfile import TemporaryDirectory
 ROOT = Path(__file__).resolve().parent.parent
 
 SOURCE = r'''
-#include "common/addon/speaker_group_helpers.h"
+#include "components/speaker_group_helpers/speaker_group_helpers.h"
 
 #include <iostream>
 #include <string>


### PR DESCRIPTION
## Summary

- move the speaker-group parser into a repository-owned ESPHome external component
- remove the package-relative `esphome.includes` path that breaks remote `url + files` packages
- update local development component lists and troubleshooting guidance

## Why

ESPHome resolves `esphome.includes` paths in package files relative to the user's main YAML file. Remote package users therefore receive `speaker_group has not been declared` compile failures. Loading the helper through the existing external-component checkout avoids that path-resolution bug.

This implementation follows the working approach reported in detiber/esphome-media-player#1, adapted to keep this repository's component sources and ownership.

Closes #137.

## Validation

- `npm run check:all`
- ESPHome 2026.7.0 source generation passed for all five factory configurations
- focused C++ compile passed for the new component class and parser API
- full firmware linking was not completed locally: Docker Desktop is unavailable, and the native ESP-IDF component manager is blocked by the macOS sandbox from reading the process list. Disabling the manager allows compilation to start but omits required dependencies such as ArduinoJson. CI should run the complete firmware builds.

## Documentation decision

- [x] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [ ] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Added a troubleshooting entry for users upgrading from the affected package include.