### PR TITLE
Recommend migration to EspControl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ESPHome Media Player for Home Assistant
 
+> [!IMPORTANT]
+> **Support for ESPHome Media Player is ending.** Please migrate to [EspControl](https://jtenniswood.github.io/espcontrol/), which includes all the features from this project and more. Follow the [migration guide](https://jtenniswood.github.io/espcontrol/getting-started/migrate-esphome-media-player) to move your device across.
+
 Turn an ESP32 touchscreen into a dedicated music controller for your home.
 
 This project gives Home Assistant users a small, always-on display for their speakers. It shows album artwork, track details, playback progress, volume, and useful controls without needing to open the Home Assistant app or pick up a phone.

--- a/docs/.vitepress/theme/components/MigrationBanner.vue
+++ b/docs/.vitepress/theme/components/MigrationBanner.vue
@@ -1,0 +1,86 @@
+<template>
+  <aside class="sp-migration-banner" aria-label="Project migration notice">
+    <div class="sp-migration-banner__inner">
+      <p>
+        <strong>ESPHome Media Player support is ending.</strong>
+        Move to EspControl for all these features and more.
+      </p>
+      <a href="https://jtenniswood.github.io/espcontrol/getting-started/migrate-esphome-media-player">
+        View migration guide <span aria-hidden="true">→</span>
+      </a>
+    </div>
+  </aside>
+</template>
+
+<style scoped>
+.sp-migration-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: var(--vp-z-index-layout-top);
+  width: 100%;
+  height: var(--vp-layout-top-height);
+  color: #ffffff;
+  background: #7c2d12;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.sp-migration-banner__inner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  max-width: 1280px;
+  height: 100%;
+  margin: 0 auto;
+  padding: 8px 24px;
+}
+
+.sp-migration-banner p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.4;
+  text-align: center;
+}
+
+.sp-migration-banner a {
+  flex: none;
+  padding: 6px 12px;
+  color: #7c2d12;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.25;
+  text-decoration: none;
+  background: #ffffff;
+  border-radius: 999px;
+}
+
+.sp-migration-banner a:hover,
+.sp-migration-banner a:focus-visible {
+  color: #431407;
+  background: #ffedd5;
+}
+
+.sp-migration-banner a:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+  .sp-migration-banner__inner {
+    gap: 10px;
+    padding: 6px 12px;
+  }
+
+  .sp-migration-banner p {
+    font-size: 12px;
+    text-align: left;
+  }
+
+  .sp-migration-banner a {
+    padding: 6px 10px;
+    font-size: 12px;
+    text-align: center;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,5 +1,6 @@
 import { defineAsyncComponent, h } from 'vue'
 import DefaultTheme from 'vitepress/theme'
+import MigrationBanner from './components/MigrationBanner.vue'
 import SupportButton from './components/SupportButton.vue'
 import './style.css'
 
@@ -7,6 +8,7 @@ export default {
   extends: DefaultTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
+      'layout-top': () => h(MigrationBanner),
       'layout-bottom': () => h(SupportButton),
     })
   },

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,3 +1,7 @@
+:root {
+  --vp-layout-top-height: 52px;
+}
+
 .sp-support-btn {
   position: fixed;
   right: 28px;
@@ -5,6 +9,12 @@
   z-index: 150;
   display: inline-block;
   line-height: 0;
+}
+
+@media (max-width: 640px) {
+  :root {
+    --vp-layout-top-height: 68px;
+  }
 }
 
 .sp-support-btn img {

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,10 +7,6 @@ description: Build a Home Assistant touchscreen media controller with ESPHome, a
 
 A touchscreen media controller for Home Assistant: album art, track info, and touch controls for any media player in your smart home. Built with [ESPHome](https://esphome.io/) and [LVGL](https://lvgl.io/).
 
-::: info Recommended: switch to EspControl
-This project has moved on to [EspControl](https://jtenniswood.github.io/espcontrol/), which now supports media cover art plus richer controls for devices and playlists. New and existing users should use EspControl for the latest media controller experience.
-:::
-
 ![Guition ESP32-P4 JC8012P4A1 touchscreen media controller showing album art](./images/guition-esp32-p4-jc8012p4a1-example1.jpg)
 
 <!-- BEGIN GENERATED HOMEPAGE DEVICE LINKS -->


### PR DESCRIPTION
## Summary

- add a prominent retirement and EspControl migration panel to the repository README
- add a responsive, site-wide migration banner above the documentation navigation
- link both notices directly to the EspControl migration guide
- replace the older home-page-only notice to avoid duplicate messaging

## Verification

- npm run check:all
- verified the migration guide returns HTTP 200
- visually checked the docs banner at desktop and mobile sizes
- confirmed the banner appears on the documentation home page and an inner page without overlap, horizontal overflow, or browser errors

Firmware compilation was not run because this change only affects documentation.