### PR TITLE
Migrate placeholder image to file platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,13 +138,14 @@ jobs:
           VERSION: ${{ github.event.release.tag_name || inputs.version }}
           RELEASE_SUMMARY: ${{ github.event.release.body || '' }}
         run: |
-          BUILD_DIR=$(dirname "$(find builds/.esphome/build -path '*/.pioenvs/*/firmware.factory.bin' -print -quit)")
+          FACTORY_IMAGE=$(find builds/.esphome/build -type f -name firmware.factory.bin -print -quit)
           mkdir -p output
 
-          if [ ! -f "${BUILD_DIR}/firmware.factory.bin" ]; then
+          if [ -z "$FACTORY_IMAGE" ] || [ ! -f "$FACTORY_IMAGE" ]; then
             echo "::error::Firmware compilation failed - factory binary not found"
             exit 1
           fi
+          BUILD_DIR=$(dirname "$FACTORY_IMAGE")
 
           OTA_IMAGE="${BUILD_DIR}/firmware.ota.bin"
           if [ ! -f "$OTA_IMAGE" ]; then
@@ -155,7 +156,7 @@ jobs:
             exit 1
           fi
 
-          sudo cp "${BUILD_DIR}/firmware.factory.bin" "output/${{ matrix.asset_slug }}.factory.bin"
+          sudo cp "$FACTORY_IMAGE" "output/${{ matrix.asset_slug }}.factory.bin"
           sudo cp "$OTA_IMAGE" "output/${{ matrix.asset_slug }}.ota.bin"
           sudo chown "$USER:$USER" output/*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  ESPHOME_VERSION: 2026.6.4
+  ESPHOME_VERSION: 2026.7.0
 
 jobs:
   release-notes:

--- a/common/addon/music.yaml
+++ b/common/addon/music.yaml
@@ -31,7 +31,8 @@ http_request:
 
 image:
   # ESPHome resolves local image files from the user's YAML folder, not the package checkout.
-  - file: "https://raw.githubusercontent.com/jtenniswood/esphome-media-player/main/common/assets/placeholder.png"
+  - platform: file
+    file: "https://raw.githubusercontent.com/jtenniswood/esphome-media-player/main/common/assets/placeholder.png"
     id: album_art_placeholder
     type: RGB565
     byte_order: ${image_byte_order}

--- a/devices/esp32-p4-86-panel/device/device.yaml
+++ b/devices/esp32-p4-86-panel/device/device.yaml
@@ -22,6 +22,7 @@
 esp32:
   variant: ESP32P4
   flash_size: 32MB
+  flash_mode: dio
   cpu_frequency: 360MHz
   # Current Waveshare 4" P4 panels report ESP-ROM:esp32p4-eco2 in the boot log.
   # ESPHome defaults P4 builds to production rev3 silicon unless this is set.
@@ -48,11 +49,9 @@ esp32:
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
-  platformio_options:
-    board_build.flash_mode: dio
-    build_flags:
-      - "-DCONFIG_LV_DISP_DEF_REFR_PERIOD=10"
-      - "-Wno-deprecated-declarations"
+  build_flags:
+    - "-DCONFIG_LV_DISP_DEF_REFR_PERIOD=10"
+    - "-Wno-deprecated-declarations"
 
 
 # -----------------------------------------------------------------------------

--- a/devices/guition-esp32-p4-jc1060p470/device/device.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/device.yaml
@@ -19,6 +19,7 @@
 esp32:
   variant: ESP32P4
   flash_size: 16MB
+  flash_mode: dio
   cpu_frequency: 360MHz
   engineering_sample: true
   framework:
@@ -53,11 +54,9 @@ esphome:
           brightness: 100%
           transition_length: 500ms
       - script.execute: backlight_wake_timeout
-  platformio_options:
-    board_build.flash_mode: dio
-    build_flags:
-      - "-DCONFIG_LV_DISP_DEF_REFR_PERIOD=10"
-      - "-Wno-deprecated-declarations"
+  build_flags:
+    - "-DCONFIG_LV_DISP_DEF_REFR_PERIOD=10"
+    - "-Wno-deprecated-declarations"
 
 
 # ESP32-C6 coprocessor for Wi-Fi and Bluetooth via SDIO

--- a/devices/guition-esp32-p4-jc4880p443/device/device.yaml
+++ b/devices/guition-esp32-p4-jc4880p443/device/device.yaml
@@ -19,6 +19,7 @@
 esp32:
   variant: ESP32P4
   flash_size: 16MB
+  flash_mode: dio
   cpu_frequency: 360MHz
   engineering_sample: true
   framework:
@@ -53,11 +54,9 @@ esphome:
           brightness: 100%
           transition_length: 500ms
       - script.execute: backlight_wake_timeout
-  platformio_options:
-    board_build.flash_mode: dio
-    build_flags:
-      - "-DCONFIG_LV_DISP_DEF_REFR_PERIOD=10"
-      - "-Wno-deprecated-declarations"
+  build_flags:
+    - "-DCONFIG_LV_DISP_DEF_REFR_PERIOD=10"
+    - "-Wno-deprecated-declarations"
 
 
 # ESP32-C6 coprocessor for Wi-Fi and Bluetooth via SDIO

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -13,6 +13,7 @@
 esp32:
   variant: ESP32P4
   flash_size: 16MB
+  flash_mode: dio
   engineering_sample: true
   framework:
     type: esp-idf
@@ -36,11 +37,9 @@ esphome:
           brightness: 100%
           transition_length: 500ms
       - script.execute: backlight_wake_timeout
-  platformio_options:
-    board_build.flash_mode: dio
-    build_flags:
-      - "-DCONFIG_LV_DISP_DEF_REFR_PERIOD=10"
-      - "-Wno-deprecated-declarations"
+  build_flags:
+    - "-DCONFIG_LV_DISP_DEF_REFR_PERIOD=10"
+    - "-Wno-deprecated-declarations"
 
 
 # ESP32-C6 coprocessor for WiFi and Bluetooth via SDIO

--- a/docs/advanced/esphome-config.md
+++ b/docs/advanced/esphome-config.md
@@ -9,7 +9,7 @@ Install the media player firmware via the ESPHome dashboard instead of the web i
 
 ## Prerequisites
 
-- [ESPHome](https://esphome.io/) 2026.6.4 or newer running (as a Home Assistant add-on or standalone)
+- [ESPHome](https://esphome.io/) 2026.7.0 or newer running (as a Home Assistant add-on or standalone)
 - Your device connected via USB for the first flash (OTA updates work after that)
 
 ## Create a configuration


### PR DESCRIPTION
## Summary

- declare the album-art placeholder as an explicit `file` image platform
- remove the ESPHome 2027.1 deprecation warning without changing the image source or format

## Root cause

ESPHome 2026.7 deprecated implicit file images under the top-level `image:` component. The shared music configuration still used the legacy implicit format.

## User impact

Firmware configuration no longer emits the deprecated `image:` format warning and remains compatible with the platform-based format required by ESPHome 2027.1.

## Validation

Compiled successfully with ESPHome 2026.7.0:

- `builds/guition-esp32-p4-jc1060p470.factory.yaml`
- `builds/guition-esp32-p4-jc4880p443.factory.yaml`
- `builds/guition-esp32-s3-4848s040.factory.yaml`

The reported image deprecation warning was absent from all three builds.